### PR TITLE
ITM-83: Address injury/treatment TODOs

### DIFF
--- a/swagger_server/itm/itm_scenario_session.py
+++ b/swagger_server/itm/itm_scenario_session.py
@@ -299,27 +299,19 @@ class ITMScenarioSession:
     def _reveal_injuries(self, source: Casualty, target: Casualty):
         if target.assessed: # Don't reveal injuries in assessed casualties
             return
+
         for source_injury in source.injuries:
-            # TBD: Hidden injuries should be configurable by type or injury instance
-            found_burn = False
-            if source_injury.name == 'Burn': # Casualty has a burn injury
-                for target_injury in target.injuries:
-                    if target_injury.name == 'Burn': # Burn has already been revealed
-                        found_burn = True
-                        break
-                if not found_burn:
-                    target.injuries.append(source_injury)
+            if source_injury.name in self.current_isso.hidden_injury_types and \
+                not any(target_injury.name in self.current_isso.hidden_injury_types \
+                        for target_injury in target.injuries): \
+                            target.injuries.append(source_injury)
 
-
+    # Hide vitals and hidden injuries at start of scenario
     def _clear_hidden_data(self):
         for casualty in self.scenario.state.casualties:
-            for injury in casualty.injuries:
-                if injury.name == 'Burn':
-                    # Hide Burn injuries until action taken on casualty
-                    # TBD: hidden injuries should be configurable by type or injury instance
-                    casualty.injuries.remove(injury)
+            casualty.injuries[:] = \
+                [injury for injury in casualty.injuries if injury.name not in self.current_isso.hidden_injury_types]
             casualty.vitals = Vitals()
-        pass
 
 
     def get_alignment_target(self, session_id: str, scenario_id: str) -> AlignmentTarget:

--- a/swagger_server/itm/itm_scenario_session.py
+++ b/swagger_server/itm/itm_scenario_session.py
@@ -626,14 +626,14 @@ class ITMScenarioSession:
         """
 
         casualty.tag = tag
-        casualties: List[Casualty] = self.current_isso.scenario.state.casualties
-        for isso_casualty in casualties:
+        for isso_casualty in self.current_isso.scenario.state.casualties:
             if isso_casualty.id == casualty.id:
                 # Certain basic vitals are discovered when a casualty is approached.
                 casualty.vitals.breathing = isso_casualty.vitals.breathing
                 casualty.vitals.conscious = isso_casualty.vitals.conscious
                 casualty.vitals.mental_status = isso_casualty.vitals.mental_status
                 self._reveal_injuries(isso_casualty, casualty)
+                casualty.assessed = True
                 self._add_history(
                     "Tag Casualty",
                     {"Session ID": self.session_id, "Casualty ID": casualty.id, "Tag": tag},

--- a/swagger_server/itm/itm_session_scenario_object.py
+++ b/swagger_server/itm/itm_session_scenario_object.py
@@ -19,6 +19,7 @@ class ITMSessionScenarioObject:
     casualty_simulations: List[CasualtySimulation] = None
     casualty_simulator: ITMCasualtySimulator = None
     supplies: ITMSupplies = None
+    hidden_injury_types = ['Burn'] # TBD: Hidden injuries should be configurable by type or injury instance
     ta1_controller: ITMTa1Controller = None
 
 class ITMSessionScenarioObjectHandler:


### PR DESCRIPTION
* Hide Burn injuries at start;
* Reveal injuries in state based on ADM actions based on resolution of ITM-82;
  * Do not treat/remove injuries that haven’t been discovered by ADMs;
* Validate that you have sufficient Supplies to treat an injury; and
* Only remove an Injury and decrement Supplies if the APPLY_TREATMENT action specifies the correct treatment/location for the injury.