### PR TITLE
ITM-96:  Add END_SCENARIO to the API and tweak custom September scenario/action progression

### DIFF
--- a/swagger_server/itm/itm_scenario_session.py
+++ b/swagger_server/itm/itm_scenario_session.py
@@ -46,7 +46,7 @@ class ITMScenarioSession:
         self.first_answer: bool = True
         # hacky stuff for adept
         self.casualty_ids = []
-        self.probes_responded_to = []
+        self.adept_evac_happened = False
         # hacky thing for ST
         self.patients_treated = 0
         # adept or ST
@@ -175,6 +175,8 @@ class ITMScenarioSession:
                 tag = action.parameters.get("category")
                 if not tag in allowed_values:
                     return 'Invalid or Malformed Action: Invalid Tag', 400
+        elif action.action_type == "END_SCENARIO":
+            pass
         else:
             return False, 'Invalid action_type', 400
         
@@ -191,6 +193,9 @@ class ITMScenarioSession:
         """
         End the current scenario and store history to mongo and json file.
         """
+        self.scenario.state.scenario_complete = True
+        self.adept_evac_happened = False
+
         if self.ta1_integration == True:
             alignment_target_session_alignment = \
                 self.current_isso.ta1_controller.get_session_alignment()
@@ -202,17 +207,14 @@ class ITMScenarioSession:
             )
         else:
             print("--> Getting session alignment from TA1.")
-        if not self.save_to_database:
-            self.history = []
-            self.probes_responded_to = []
-            return
-        self.mongo_db.insert_data('scenarios', self.scenario.to_dict())
-        insert_id = self.mongo_db.insert_data('test', {"history": self.history})
-        retrieved_data = self.mongo_db.retrieve_data('test', insert_id)
-        # Write the retrieved data to a local JSON file
-        self.mongo_db.write_to_json_file(retrieved_data)
+
+        if self.save_to_database:
+            self.mongo_db.insert_data('scenarios', self.scenario.to_dict())
+            insert_id = self.mongo_db.insert_data('test', {"history": self.history})
+            retrieved_data = self.mongo_db.retrieve_data('test', insert_id)
+            # Write the retrieved data to a local JSON file
+            self.mongo_db.write_to_json_file(retrieved_data)
         self.history = []
-        self.probes_responded_to = []
 
 
     def _get_realtime_elapsed_time(self) -> float:
@@ -568,7 +570,6 @@ class ITMScenarioSession:
         self.session_issos = []
         self.session_type = session_type
         self.history = []
-        self.probes_responded_to = []
 
         # Save to database based on adm_name.
         if self.adm_name.endswith("_db_"):
@@ -678,7 +679,6 @@ class ITMScenarioSession:
         Args:
             body: The probe response body as a dict.
         """
-        self.probes_responded_to.append(body.probe_id)
         body.justification = '' if body.justification == None else body.justification
         self.current_isso.probe_system.respond_to_probe(
             probe_id=body.probe_id,
@@ -820,6 +820,11 @@ class ITMScenarioSession:
             self.scenario.state.to_dict())
         print(f"--> ADM chose action {body.action_type} with casualty {body.casualty_id} and parameters {body.parameters}.")
 
+        # Only the ADM can end the scenario
+        if body.action_type == 'END_SCENARIO':
+            self._end_scenario()
+            return self.scenario.state
+
         # Map action to probe response
         response = self.lookup_probe_response(action=body)
 
@@ -859,19 +864,13 @@ class ITMScenarioSession:
             # Update scenario state
             self.update_state(action=body)
             if body.action_type == "MOVE_TO_EVAC":
-                self.end_probe()
-                self._end_scenario()
+                self.adept_evac_happened = True
             # if no unanswered casualties left, (or no options left)
             elif not unanswered_casualty_id or not self.current_isso.probe_system.probe_yamls[self.current_isso.probe_system.current_probe_index]:
                 self.end_probe()
         else:
-            #PROBE HANDLING FOR SOARTECH
-            if body.action_type == "APPLY_TREATMENT": self.patients_treated += 1
+            # PROBE HANDLING FOR SOARTECH
             self.update_state(action=body)
-            if self.patients_treated >= 3:
-                self.end_probe()
-                # Only one probe, scenario ends when all three patients treated
-                self._end_scenario()
 
         return self.scenario.state
 
@@ -917,12 +916,15 @@ class ITMScenarioSession:
             return 'Scenario Complete', 400
 
         actions: List[Action] = []
-        
-        if self.current_isso.probe_system.probe_yamls:
-            for option in self.current_isso.probe_system.probe_yamls[self.current_isso.probe_system.current_probe_index].options:
-                if (not self.kdma_training):
-                    option.assoc_action.pop('kdma_association', None)
-                actions.append(option.assoc_action)
+        if self.current_isso.probe_system.probe_yamls and not self.scenario.state.scenario_complete:
+            if not self.adept_evac_happened:
+                for option in self.current_isso.probe_system.probe_yamls[self.current_isso.probe_system.current_probe_index].options:
+                    if (not self.kdma_training):
+                        option.assoc_action.pop('kdma_association', None)
+                    actions.append(option.assoc_action)
+            if self.scenario_rules == 'SOARTECH' or self.adept_evac_happened:
+                # Allow ADMs to end the scenario, usually
+                actions.append(Action(action_id="end_scenario_action", scenario_id=scenario_id, action_type='END_SCENARIO', unstructured="End the scenario"))
             # Always allow tagging a casualty
             actions.append(Action(action_id="tag_action", scenario_id=scenario_id, action_type='TAG_CASUALTY', unstructured="Tag a casualty"))
         else:

--- a/swagger_server/models/action.py
+++ b/swagger_server/models/action.py
@@ -145,7 +145,7 @@ class Action(Model):
         :param action_type: The action_type of this Action.
         :type action_type: str
         """
-        allowed_values = ["APPLY_TREATMENT", "CHECK_ALL_VITALS", "CHECK_PULSE", "CHECK_RESPIRATION", "DIRECT_MOBILE_CASUALTIES", "MOVE_TO_EVAC", "SITREP", "TAG_CASUALTY"]  # noqa: E501
+        allowed_values = ["APPLY_TREATMENT", "CHECK_ALL_VITALS", "CHECK_PULSE", "CHECK_RESPIRATION", "DIRECT_MOBILE_CASUALTIES", "END_SCENARIO", "MOVE_TO_EVAC", "SITREP", "TAG_CASUALTY"]  # noqa: E501
         if action_type not in allowed_values:
             raise ValueError(
                 "Invalid value for `action_type` ({0}), must be one of {1}"

--- a/swagger_server/swagger/swagger.yaml
+++ b/swagger_server/swagger/swagger.yaml
@@ -987,6 +987,7 @@ components:
           - CHECK_PULSE
           - CHECK_RESPIRATION
           - DIRECT_MOBILE_CASUALTIES
+          - END_SCENARIO
           - MOVE_TO_EVAC
           - SITREP
           - TAG_CASUALTY


### PR DESCRIPTION
* Add END_SCENARIO to action space/API;
* SoarTech:  END_SCENARIO is always available; server only ends the scenario in response to END_SCENARIO ;
* BBN:  END_SCENARIO is not initially available; once ADM performs a MOVE_TO_EVAC action, the only available actions will be END_SCENARIO and TAG_PATIENT, the latter of which is always available.

Testing requires pulling ITM-96 branch from `itm-evaluation-client`.