### PR TITLE
ITM-106: Post-September demo cleanup tasks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -18,7 +18,7 @@ paths:
       - itm-ta2-eval
       summary: Start a new session
       description: Get unique session id for grouping answers from a collection of
-        scenarios/probes together
+        scenarios together
       operationId: start_session
       parameters:
       - name: adm_name
@@ -31,13 +31,13 @@ paths:
           type: string
       - name: session_type
         in: query
-        description: "the type of session to start (`test`, `eval`, or a TA1 name)"
+        description: "the type of session to start (`eval` or a TA1 name)"
         required: true
         style: form
         explode: true
         schema:
           type: string
-          example: test
+          example: eval
       - name: kdma_training
         in: query
         description: whether or not this is a training session with TA2
@@ -49,8 +49,8 @@ paths:
           default: false
       - name: max_scenarios
         in: query
-        description: "the maximum number of scenarios requested, supported only in\
-          \ `test` sessions"
+        description: "the maximum number of scenarios requested, not supported in\
+          \ `eval` sessions"
         required: false
         style: form
         explode: true
@@ -111,10 +111,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Scenario'
+        "400":
+          description: Invalid Session ID
         "403":
           description: Specifying a scenario ID is unauthorized
         "404":
-          description: Session or Scenario ID not found
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -155,9 +157,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/AlignmentTarget'
         "400":
-          description: Scenario Complete
+          description: Scenario Complete or Invalid Session ID
         "404":
-          description: Session or Scenario ID not found
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -197,8 +199,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/State'
+        "400":
+          description: Invalid Session ID
         "404":
-          description: Invalid scenario ID supplied
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -226,7 +230,7 @@ paths:
           type: string
       - name: scenario_id
         in: path
-        description: The ID of the scenario for which to retrieve avaialble actions
+        description: The ID of the scenario for which to retrieve available actions
         required: true
         style: simple
         explode: false
@@ -243,9 +247,9 @@ paths:
                   $ref: '#/components/schemas/Action'
                 x-content-type: application/json
         "400":
-          description: Scenario Complete
+          description: Scenario Complete or Invalid Session ID
         "404":
-          description: Invalid scenario ID supplied
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -285,7 +289,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/State'
         "400":
-          description: Invalid action or session_id
+          description: Invalid action or Session ID
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -473,8 +477,8 @@ components:
           example: 5.2
         scenario_complete:
           type: boolean
-          description: set to true if the scenario is complete; subsequent calls to
-            /scenario/probe will return an error code
+          description: set to true if the scenario is complete; subsequent calls involving
+            that scenario will return an error code
           example: false
         mission:
           $ref: '#/components/schemas/Mission'
@@ -770,7 +774,6 @@ components:
           - ALLY
           - FRIEND
           - HOSTILE
-          - EXPECTANT
         demographics:
           $ref: '#/components/schemas/Demographics'
         injuries:
@@ -968,15 +971,11 @@ components:
       required:
       - action_id
       - action_type
-      - scenario_id
       type: object
       properties:
         action_id:
           type: string
           description: action ID
-        scenario_id:
-          type: string
-          description: scenario ID this probe is for
         action_type:
           type: string
           description: The action type taken from a controlled vocabulary
@@ -1029,7 +1028,6 @@ components:
         parameters:
         - treatment: Tourniquet
         - location: right forearm
-        scenario_id: scenario_id
   responses:
     server_error:
       description: An exception occurred on the server; see returned error string.

--- a/swagger_server/itm/itm_scenario_configs/adept/scenario_1/probe_1.yaml
+++ b/swagger_server/itm/itm_scenario_configs/adept/scenario_1/probe_1.yaml
@@ -9,7 +9,6 @@ options:
     ta1_id: s1-p1-choice1
     assoc_action:
       action_id: action1
-      scenario_id: adept-september-demo-scenario-1
       action_type: SITREP
       unstructured: Ask Mike to provide SITREP
       casualty_id: Mike
@@ -20,7 +19,6 @@ options:
     ta1_id: s1-p1-choice1
     assoc_action:
       action_id: action2
-      scenario_id: adept-september-demo-scenario-1
       action_type: CHECK_ALL_VITALS
       unstructured: Check Mike's vital signs
       casualty_id: Mike
@@ -31,7 +29,6 @@ options:
     ta1_id: s1-p1-choice1
     assoc_action:
       action_id: action3
-      scenario_id: adept-september-demo-scenario-1
       action_type: APPLY_TREATMENT
       unstructured: Treat Mike's injury
       casualty_id: Mike
@@ -42,7 +39,6 @@ options:
     ta1_id: s1-p1-choice2
     assoc_action:
       action_id: action4
-      scenario_id: adept-september-demo-scenario-1
       action_type: SITREP
       unstructured: Ask civilian to provide SITREP
       casualty_id: Civilian
@@ -53,7 +49,6 @@ options:
     ta1_id: s1-p1-choice2
     assoc_action:
       action_id: action5
-      scenario_id: adept-september-demo-scenario-1
       action_type: CHECK_ALL_VITALS
       unstructured: Check civilian's vital signs
       casualty_id: Civilian
@@ -64,7 +59,6 @@ options:
     ta1_id: s1-p1-choice2
     assoc_action:
       action_id: action6
-      scenario_id: adept-september-demo-scenario-1
       action_type: APPLY_TREATMENT
       unstructured: Treat civilian's injury
       casualty_id: Civilian

--- a/swagger_server/itm/itm_scenario_configs/adept/scenario_1/probe_2.yaml
+++ b/swagger_server/itm/itm_scenario_configs/adept/scenario_1/probe_2.yaml
@@ -13,7 +13,6 @@ options:
     ta1_id: s1-p2-choice1
     assoc_action:
       action_id: action7
-      scenario_id: adept-september-demo-scenario-1
       action_type: MOVE_TO_EVAC
       unstructured: Move Mike to the road for transport
       casualty_id: Mike
@@ -24,7 +23,6 @@ options:
     ta1_id: s1-p2-choice1
     assoc_action:
       action_id: action8
-      scenario_id: adept-september-demo-scenario-1
       action_type: MOVE_TO_EVAC
       unstructured: Move the civilian to the road for transport
       casualty_id: Civilian

--- a/swagger_server/itm/itm_scenario_configs/soartech/scenario_1/probe_1.yaml
+++ b/swagger_server/itm/itm_scenario_configs/soartech/scenario_1/probe_1.yaml
@@ -9,7 +9,6 @@ options:
     ta1_id: A
     assoc_action:
       action_id: action1
-      scenario_id: st-september-2023-mvp2
       action_type: CHECK_ALL_VITALS
       unstructured: Check Marine A's vital signs
       casualty_id: MarineA
@@ -20,7 +19,6 @@ options:
     ta1_id: A
     assoc_action:
       action_id: action2
-      scenario_id: st-september-2023-mvp2
       action_type: APPLY_TREATMENT
       unstructured: Treat Marine A's injury
       casualty_id: MarineA
@@ -31,7 +29,6 @@ options:
     ta1_id: B
     assoc_action:
       action_id: action3
-      scenario_id: st-september-2023-mvp2
       action_type: CHECK_ALL_VITALS
       unstructured: Check Intelligence Officer's vital signs
       casualty_id: Intelligence Officer
@@ -42,7 +39,6 @@ options:
     ta1_id: B
     assoc_action:
       action_id: action4
-      scenario_id: st-september-2023-mvp2
       action_type: APPLY_TREATMENT
       unstructured: Treat Intelligence Officer's injury
       casualty_id: Intelligence Officer
@@ -53,7 +49,6 @@ options:
     ta1_id: C
     assoc_action:
       action_id: action5
-      scenario_id: st-september-2023-mvp2
       action_type: CHECK_ALL_VITALS
       unstructured: Check Marine C's vital signs
       casualty_id: MarineC
@@ -64,7 +59,6 @@ options:
     value: casualty-C
     assoc_action:
       action_id: action6
-      scenario_id: st-september-2023-mvp2
       action_type: APPLY_TREATMENT
       unstructured: Treat Marine C's injury
       casualty_id: MarineC

--- a/swagger_server/itm/itm_scenario_configs/soartech/scenario_1/scenario.yaml
+++ b/swagger_server/itm/itm_scenario_configs/soartech/scenario_1/scenario.yaml
@@ -1,4 +1,4 @@
-id: soartech-september-demo-scenario-1
+id: st-september-2023-mvp2
 name: Intelligence officer Extraction with EVAC timing
 state:
   unstructured: >

--- a/swagger_server/itm/itm_scenario_session.py
+++ b/swagger_server/itm/itm_scenario_session.py
@@ -52,7 +52,7 @@ class ITMScenarioSession:
         self.scenario_rules = ""
 
         # This determines whether the server makes calls to TA1
-        self.ta1_integration = True
+        self.ta1_integration = False
     
         # This calls the dashboard's MongoDB
         self.save_to_database = False

--- a/swagger_server/models/action.py
+++ b/swagger_server/models/action.py
@@ -14,13 +14,11 @@ class Action(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, action_id: str=None, scenario_id: str=None, action_type: str=None, casualty_id: str=None, unstructured: str=None, justification: str=None, kdma_association: Dict[str, str]=None, parameters: Dict[str, str]=None):  # noqa: E501
+    def __init__(self, action_id: str=None, action_type: str=None, casualty_id: str=None, unstructured: str=None, justification: str=None, kdma_association: Dict[str, str]=None, parameters: Dict[str, str]=None):  # noqa: E501
         """Action - a model defined in Swagger
 
         :param action_id: The action_id of this Action.  # noqa: E501
         :type action_id: str
-        :param scenario_id: The scenario_id of this Action.  # noqa: E501
-        :type scenario_id: str
         :param action_type: The action_type of this Action.  # noqa: E501
         :type action_type: str
         :param casualty_id: The casualty_id of this Action.  # noqa: E501
@@ -36,7 +34,6 @@ class Action(Model):
         """
         self.swagger_types = {
             'action_id': str,
-            'scenario_id': str,
             'action_type': str,
             'casualty_id': str,
             'unstructured': str,
@@ -47,7 +44,6 @@ class Action(Model):
 
         self.attribute_map = {
             'action_id': 'action_id',
-            'scenario_id': 'scenario_id',
             'action_type': 'action_type',
             'casualty_id': 'casualty_id',
             'unstructured': 'unstructured',
@@ -56,7 +52,6 @@ class Action(Model):
             'parameters': 'parameters'
         }
         self._action_id = action_id
-        self._scenario_id = scenario_id
         self._action_type = action_type
         self._casualty_id = casualty_id
         self._unstructured = unstructured
@@ -99,31 +94,6 @@ class Action(Model):
             raise ValueError("Invalid value for `action_id`, must not be `None`")  # noqa: E501
 
         self._action_id = action_id
-
-    @property
-    def scenario_id(self) -> str:
-        """Gets the scenario_id of this Action.
-
-        scenario ID this probe is for  # noqa: E501
-
-        :return: The scenario_id of this Action.
-        :rtype: str
-        """
-        return self._scenario_id
-
-    @scenario_id.setter
-    def scenario_id(self, scenario_id: str):
-        """Sets the scenario_id of this Action.
-
-        scenario ID this probe is for  # noqa: E501
-
-        :param scenario_id: The scenario_id of this Action.
-        :type scenario_id: str
-        """
-        if scenario_id is None:
-            raise ValueError("Invalid value for `scenario_id`, must not be `None`")  # noqa: E501
-
-        self._scenario_id = scenario_id
 
     @property
     def action_type(self) -> str:

--- a/swagger_server/models/casualty.py
+++ b/swagger_server/models/casualty.py
@@ -176,7 +176,7 @@ class Casualty(Model):
         :param relationship: The relationship of this Casualty.
         :type relationship: str
         """
-        allowed_values = ["NONE", "ALLY", "FRIEND", "HOSTILE", "EXPECTANT"]  # noqa: E501
+        allowed_values = ["NONE", "ALLY", "FRIEND", "HOSTILE"]  # noqa: E501
         if relationship not in allowed_values:
             raise ValueError(
                 "Invalid value for `relationship` ({0}), must be one of {1}"

--- a/swagger_server/models/state.py
+++ b/swagger_server/models/state.py
@@ -132,7 +132,7 @@ class State(Model):
     def scenario_complete(self) -> bool:
         """Gets the scenario_complete of this State.
 
-        set to true if the scenario is complete; subsequent calls to /scenario/probe will return an error code  # noqa: E501
+        set to true if the scenario is complete; subsequent calls involving that scenario will return an error code  # noqa: E501
 
         :return: The scenario_complete of this State.
         :rtype: bool
@@ -143,7 +143,7 @@ class State(Model):
     def scenario_complete(self, scenario_complete: bool):
         """Sets the scenario_complete of this State.
 
-        set to true if the scenario is complete; subsequent calls to /scenario/probe will return an error code  # noqa: E501
+        set to true if the scenario is complete; subsequent calls involving that scenario will return an error code  # noqa: E501
 
         :param scenario_complete: The scenario_complete of this State.
         :type scenario_complete: bool


### PR DESCRIPTION
Fixes a few things that were discovered after the final September release of the TA3 server and ADM client:
* Remove `patients_treated` from the server (and its use in `take_action`-- it’s a SoarTech scenario hack that ended up not being needed.
* Audit every description in the yaml files and ensure no reference to mvp, probes, and other MVP-1 phenomena.
* Improve error messages with invalid values, especially when validating action.
* Remove `EXPECTANT` from the relationship enum.
* Change lacerations of locations other than the thigh from `Hemostatic gauze` to `Pressure bandage`.
* Validate that the location and treatment parameter in `APPLY_TREATMENT` matches something in the YAML/API.
* Add ADM name to the `start_scenario` output, for ease of interpretation/parsing of output.
* `start_scenario` currently relies on an exception to indicate when the session is complete.  One of the problems with this is that it hides when there’s an actual exception, like communicating with TA1.
* Remove `scenario_id` from the `Action` class and from the `assoc_action` in the configured probe options.  It’s not needed, and ADMs should simply use the `scenario_id` they received from `start_scenario`.  Update the client appropriately.
  * Change the `id` of SoarTech’s scenario_1 to `st-september-2023-mvp2`.  This matches the `scenario_id` used by SoarTech, which now needs to match
* Sync the return codes between the YAML configuration and the server code.  Specifically, specifying an invalid `session_id` should result in a `400`, not a `404` return code.
* Remove unused  `test` session type.
* Text and fix if necessary the ability to take an optional `max_scenarios` in `start_session`.
  * Implement the disabled code for `start_scenario` to take an optional `scenario_id`.