### PR TITLE
ITM-121 and ITM-119: more minor server fixes

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -112,7 +112,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Scenario'
         "400":
-          description: Invalid Session ID
+          description: Invalid Session ID or there is already an active scenario
         "403":
           description: Specifying a scenario ID is unauthorized
         "404":
@@ -898,6 +898,7 @@ components:
           - right face
           - left neck
           - right neck
+          - internal
           - unspecified
         severity:
           type: number


### PR DESCRIPTION
These were some thing that were not encountered/needed in the September milestone, but are now fixed:
* Fix error validating bad tag categories specified by the ADM
* Fix elapsed time saving to database
* Fix bug in handling SITREP of all casualties (i.e., when no `casualty_id` is specified)
* Handle when ADM calls `start_scenario` prior to ending the previous scenario via `END_SCENARIO`.
  * Return 400 code
* Update/fix some casualty injuries/treatments

**NOTE**:  There will be as small PR forthcoming for `itm-evaluation-client` for the minor changes to the swagger API.