### PR TITLE
ITM-252: Better output file naming for JSON

### DIFF
--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -40,7 +40,7 @@ class ITMHistory:
         self.history.append(history_to_add)
 
 
-    def write_to_json_file(self) -> None:
+    def write_to_json_file(self, filebasename) -> None:
         """
         Write data to a JSON file.
 
@@ -53,14 +53,9 @@ class ITMHistory:
 
         # Make directory if it doesn't exist
         os.makedirs(self.filepath, exist_ok=True)
-
-        # Get the list of all json files in directory
-        file_list = [f for f in os.listdir(self.filepath) if os.path.isfile(os.path.join(self.filepath, f)) and f.endswith('.json')]
-
-        # Calculate file_number based on the number of files
-        file_number = len(file_list) + 1
-        file_name = f'itm_history_{file_number}.json'
-        full_filepath = self.filepath + file_name
+        filespec = self.filepath + filebasename
+        full_filepath = filespec + '.json'
+        print(f'--> Saving history to {full_filepath}')
 
         with open(full_filepath, 'w') as file:
             # Convert Python dictionary to JSON and write to file

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -2,6 +2,7 @@ import time
 import uuid
 import random
 import os
+from datetime import datetime
 from typing import List
 from copy import deepcopy
 from swagger_server.models import (
@@ -156,7 +157,10 @@ class ITMSession:
 
     def _cleanup(self):
         if self.save_history:
-            self.history.write_to_json_file()
+            alignment_type = 'high' if 'high' in self.itm_scenario.alignment_target.id.lower() else 'low'
+            timestamp = f"{datetime.now():%b%d-%H.%M.%S}" # e.g., "jungle-1-soartech-high-Mar13-11.44.44"
+            filename = f"{self.itm_scenario.id.replace(' ', '_')}-{self.itm_scenario.scene_type}-{alignment_type}-{timestamp}"
+            self.history.write_to_json_file(filename)
         self.history.clear_history()
 
 


### PR DESCRIPTION
Change history filename to `<scenario_id>-<ta1>-<alignment>-<date>.json` e.g.
- e.g., `MetricsEval.MD4-Jungle-adept-high-Mar13-11.45.36.json`
- e.g., `submarine-1-soartech-high-Mar13-11.44.45.json`

To test, run the development client with the  `--eval` flag and check out the results in the server's `itm_history_output` folder.
This requires both TA1 servers running, but you can also try a standalone session (e.g., with `--session adept` instead of `--eval`) but change `self.save_history = True` in `itm_session.py`.