### PR TITLE
ITM-253 - Eval server history to s3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
-<<<<<<< HEAD
 boto3 >= 1.34.61
-connexion >= 2.6.0
-connexion[swagger-ui] >= 2.6.0
-=======
 connexion >= 2.14.0, < 3.0
 connexion[swagger-ui] >= 2.14.0, < 3.0
->>>>>>> development
 python_dateutil == 2.6.0
 setuptools >= 21.0.0
 swagger-ui-bundle == 0.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto >= 1.34.61
+boto3 >= 1.34.61
 connexion >= 2.6.0
 connexion[swagger-ui] >= 2.6.0
 python_dateutil == 2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto >= 1.34.61
 connexion >= 2.6.0
 connexion[swagger-ui] >= 2.6.0
 python_dateutil == 2.6.0

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -65,6 +65,7 @@ class ITMHistory:
         with open(full_filepath, 'w') as file:
             # Convert Python dictionary to JSON and write to file
             json.dump({'history': self.history}, file, indent=2)
+
         self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename)
 
     def save_json_to_s3(self, full_filepath, file_name) -> bool:

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -1,5 +1,8 @@
+import boto3
 import json
 import os
+
+from botocore.exceptions import ClientError
 from typing import Union
 
 class ITMHistory:
@@ -13,6 +16,8 @@ class ITMHistory:
         """
         self.history = []
         self.filepath = 'itm_history_output' + os.sep
+        # TODO: Centralize settings
+        self.save_history_bucket = "itm-ui-assets"
 
     def clear_history(self):
         self.history.clear()
@@ -65,3 +70,29 @@ class ITMHistory:
         with open(full_filepath, 'w') as file:
             # Convert Python dictionary to JSON and write to file
             json.dump({'history': self.history}, file, indent=2)
+        self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, file_name)
+    def save_json_to_s3(self, full_filepath, file_name) -> bool:
+        """
+        Copy file to S3
+
+        Args:
+            full_filepath: The file object to be copied to S3.
+            file_name: File name, used as S3 object name.
+
+        Returns:
+            True if file was uploaded, else False
+        """
+
+        # If S3 object_name was not specified, use file_name
+        # if object_name is None:
+        object_name = os.path.basename(file_name)
+
+        # Upload the file
+        s3_client = boto3.client('s3')
+        try:
+            response = s3_client.upload_file(full_filepath, self.save_history_bucket, object_name)
+        except ClientError as e:
+            # TODO: Add logging: logging.error(e)
+            print(e)
+            return False
+        return True        

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -45,7 +45,7 @@ class ITMHistory:
         self.history.append(history_to_add)
 
 
-    def write_to_json_file(self, filebasename) -> None:
+    def write_to_json_file(self, filebasename, save_to_s3) -> None:
         """
         Write data to a JSON file.
 
@@ -66,7 +66,8 @@ class ITMHistory:
             # Convert Python dictionary to JSON and write to file
             json.dump({'history': self.history}, file, indent=2)
 
-        self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename  + '.json')
+        if (save_to_s3):
+            self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename  + '.json')
 
     def save_json_to_s3(self, full_filepath, file_name) -> bool:
         """

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -65,7 +65,8 @@ class ITMHistory:
         with open(full_filepath, 'w') as file:
             # Convert Python dictionary to JSON and write to file
             json.dump({'history': self.history}, file, indent=2)
-        self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, file_name)
+        self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename)
+
     def save_json_to_s3(self, full_filepath, file_name) -> bool:
         """
         Copy file to S3

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -66,7 +66,7 @@ class ITMHistory:
             # Convert Python dictionary to JSON and write to file
             json.dump({'history': self.history}, file, indent=2)
 
-        self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename)
+        self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename  + '.json')
 
     def save_json_to_s3(self, full_filepath, file_name) -> bool:
         """

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -67,7 +67,9 @@ class ITMHistory:
             json.dump({'history': self.history}, file, indent=2)
 
         if (save_to_s3):
-            self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename  + '.json')
+            print(f'--> Saving history to S3')
+            if not self.save_json_to_s3(os.getcwd() + os.path.sep + full_filepath, filebasename  + '.json'):
+                print(f'\033[92mWARNING: Unable to save history to S3\033[00m')
 
     def save_json_to_s3(self, full_filepath, file_name) -> bool:
         """
@@ -89,7 +91,7 @@ class ITMHistory:
         s3_client = boto3.client('s3')
         try:
             response = s3_client.upload_file(full_filepath, self.save_history_bucket, object_name)
-        except ClientError as e:
+        except Exception as e:
             # TODO: Add logging: logging.error(e)
             print(e)
             return False

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -55,7 +55,7 @@ class ITMSession:
         # This determines whether the server makes calls to TA1
         self.ta1_integration = False # Default here applies to non-training, non-eval sessions
         # This determines whether the server saves history to JSON
-        self.save_history = True
+        self.save_history = False
         # save_history must also be True
         self.save_history_to_s3 = True
 
@@ -399,6 +399,7 @@ class ITMSession:
         ta1_names = []
         if self.session_type == 'eval':
             self.save_history = True
+            self.save_history_to_s3 = True
             self.ta1_integration = True
             max_scenarios = None
             ta1_names = ['soartech', 'adept']

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -55,7 +55,7 @@ class ITMSession:
         # This determines whether the server makes calls to TA1
         self.ta1_integration = False # Default here applies to non-training, non-eval sessions
         # This determines whether the server saves history to JSON
-        self.save_history = True
+        self.save_history = False
 
     def __deepcopy__(self, memo):
         return self # Allows us to deepcopy ITMScenarios

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -54,7 +54,7 @@ class ITMSession:
         # This determines whether the server makes calls to TA1
         self.ta1_integration = False # Default here applies to non-training, non-eval sessions
         # This determines whether the server saves history to JSON
-        self.save_history = False
+        self.save_history = True
 
     def __deepcopy__(self, memo):
         return self # Allows us to deepcopy ITMScenarios

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -55,7 +55,9 @@ class ITMSession:
         # This determines whether the server makes calls to TA1
         self.ta1_integration = False # Default here applies to non-training, non-eval sessions
         # This determines whether the server saves history to JSON
-        self.save_history = False
+        self.save_history = True
+        # save_history must also be True
+        self.save_history_to_s3 = True
 
     def __deepcopy__(self, memo):
         return self # Allows us to deepcopy ITMScenarios
@@ -160,7 +162,7 @@ class ITMSession:
             alignment_type = 'high' if 'high' in self.itm_scenario.alignment_target.id.lower() else 'low'
             timestamp = f"{datetime.now():%b%d-%H.%M.%S}" # e.g., "jungle-1-soartech-high-Mar13-11.44.44"
             filename = f"{self.itm_scenario.id.replace(' ', '_')}-{self.itm_scenario.scene_type}-{alignment_type}-{timestamp}"
-            self.history.write_to_json_file(filename)
+            self.history.write_to_json_file(filename, self.save_history_to_s3)
         self.history.clear_history()
 
 

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -55,7 +55,7 @@ class ITMSession:
         # This determines whether the server makes calls to TA1
         self.ta1_integration = False # Default here applies to non-training, non-eval sessions
         # This determines whether the server saves history to JSON
-        self.save_history = False
+        self.save_history = True
 
     def __deepcopy__(self, memo):
         return self # Allows us to deepcopy ITMScenarios

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -54,7 +54,7 @@ class ITMSession:
         # This determines whether the server makes calls to TA1
         self.ta1_integration = False # Default here applies to non-training, non-eval sessions
         # This determines whether the server saves history to JSON
-        self.save_history = True
+        self.save_history = False
 
     def __deepcopy__(self, memo):
         return self # Allows us to deepcopy ITMScenarios


### PR DESCRIPTION
1. Get a temporary aws access token: 
  a. you'll need aws-cli installed
  b. grab [saml-caci-all.zip](https://caci.servicenowservices.com/sys_attachment.do?sys_id=1c127be01b34f5d01afb0e9ee54bcbfa) from [here](https://caci.servicenowservices.com/caci?id=kb_article_view&table=kb_knowledge&sys_kb_id=4c12b3e01b34f5d01afb0e9ee54bcb9b&recordUrl=%2Fkb_view.do%3Fsys_kb_id%3D4c12b3e01b34f5d01afb0e9ee54bcb9b) (2nd section - # 3)
  c. unzip the above and run your OS specific command
  d. it'll generate a config and credentials file
  e. in your .aws folder (you'll have one in your home dir after installing the aws-cli), back up your config/crendetials file and replace it with the ones the saml tool created
  f. in the credentials file rename `[saml]` to `[default]`
  g. you should now be able to issue aws commands, try `aws s3 ls`, this will list all our buckets in s3
3. Start a TA1 Server (i.e. Adept) - https://gitlab.com/itm-ta1-adept-shared/adept_server
4. In itm-evaluation-server, Change line 58 `self.save_history` = False to `self.save_history = True`
5. In itm-evaluation-client, run something, i.e.:  `python itm_minimal_runner.py --adm_name test_misaligned --session adept`
6. History should be in: `itm-evaluation-server/itm_history_output`
7. Check s3 bucket: `aws s3 ls itm-ui-assets`, the history files should be there.