### PR TITLE
ITM-294 - Fix TA3 Eval API Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-boto3 >= 1.34.61
+boto3 == 1.34.61
+botocore  == 1.34.61
 connexion >= 2.14.0, < 3.0
 connexion[swagger-ui] >= 2.14.0, < 3.0
-python_dateutil == 2.6.0
+python-dateutil == 2.9.0
 setuptools >= 21.0.0
 swagger-ui-bundle == 0.0.9


### PR DESCRIPTION
Created a ticket but not sure why I'm not seeing it on the board:
https://nextcentury.atlassian.net/browse/ITM-294

There was a conflict with the python-dateutil when running inside the container.  I pinned a newer version 2.9.0.  Everything seems to be working.  I updated in production to test.

To test from the itm-evaluation-client:

export TA3_PORT="443"
export TA3_HOSTNAME="https://darpaitm.caci.com"

python itm_minimal_runner.py --adm_name test --session eval

