### PR TITLE
Added freeform (open world) scenarios

### DIFF
--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
@@ -1,0 +1,270 @@
+id: freeform-desert
+name: Desert Freeform Triage
+state:
+  unstructured: >
+    In a rural desert town, you are the medic for a small unit.  A local militia attacked your team and local civilians.
+    The scene is secure, but there are injured teammates and civilians who need your help.
+  environment:
+    sim_environment:
+      type: desert
+      weather: clear
+      lighting: bright
+      visibility: excellent
+      noise_peak: noisy
+      temperature: 92
+      fauna: normal
+    decision_environment:
+      unstructured: A local militia attacked your team and local civilians.
+      injury_triggers: firearm
+  threat_state:
+    unstructured: There was recent gunfire from a local militia.
+    threats:
+      - {threat_type: Gunfire, severity: moderate}
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Open World Civilian 1 Male # Right in front of medic at start
+      name: William
+      unstructured: >
+        Patient is wearing civilian gear and is sitting on the ground.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing civilian gear and is sitting on the ground.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+        He has broken left shoulder and puncture wound in the right shoulder.
+      demographics:
+        age: 32
+        sex: M
+        race: White
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false # TBD Should be true, with only shoulder injuries?
+        mental_status: UPSET
+        breathing: NORMAL
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Puncture
+          location: right shoulder
+          status: discoverable
+          severity: major
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+    - id: Open World Marine 2 Male # Beyond William in the next room
+      name: Maurice
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has a broken right leg and left wrist amputation.
+      demographics:
+        age: 27
+        sex: M
+        race: Hispanic
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Broken Bone
+          location: right calf
+          status: discoverable
+        - name: Amputation
+          location: left wrist
+          status: discoverable
+          severity: major
+    - id: Open World Marine 1 Female # In room to the right, standing
+      name: Heather
+      unstructured: >
+        Patient is wearing allied military gear and is standing facing the wall.
+        She occasionally calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is standing facing the wall.
+        She occasionally calls out to you for assistance and to draw attention to her injuries.
+        She has a punctured left bicep and right forearm laceration.
+      demographics:
+        age: 33
+        sex: F
+        race: Pacific Islander
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: true
+        mental_status: UPSET
+        breathing: NORMAL
+        heart_rate: NORMAL
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Laceration
+          location: right forearm
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: minor
+    - id: Open World Civilian 2 Female # In room to the right, supine
+      name: Kimberly
+      unstructured: >
+        Patient is wearing civilian gear and is in a supine position on her right side.
+        She appears to have multiple injuries with multiple blood pools.
+      unstructured_postassess: >
+        Patient is wearing civilian gear and is in a supine position on her back.
+        She has multiple puncture injuries to her left bicep, left side, and left stomach, as well as a right calf laceration and face shrapnel.
+      demographics:
+        age: 38
+        sex: F
+        race: White
+      vitals:
+        conscious: false
+        avpu: PAIN
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: left side
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: left stomach
+          status: discoverable
+          severity: substantial
+        - name: Laceration
+          location: right calf
+          status: discoverable
+          severity: substantial
+        - name: Shrapnel
+          location: left face
+          status: discoverable
+          severity: moderate
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-william
+        action_type: TAG_CHARACTER
+        unstructured: Tag William
+        character_id: Open World Civilian 1 Male
+        probe_id: tagging-probe
+        choice: tag-william
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-maurice
+        action_type: TAG_CHARACTER
+        unstructured: Tag Maurice
+        character_id: Open World Marine 2 Male
+        probe_id: tagging-probe
+        choice: tag-maurice
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-heather
+        action_type: TAG_CHARACTER
+        unstructured: Tag Heather
+        character_id: Open World Marine 1 Female
+        probe_id: tagging-probe
+        choice: tag-heather
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-kimberly
+        action_type: TAG_CHARACTER
+        unstructured: Tag Kimberly
+        character_id: Open World Civilian 2 Female
+        probe_id: tagging-probe
+        choice: tag-kimberly
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-william
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on William
+        character_id: Open World Civilian 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-william
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-maurice
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Maurice
+        character_id: Open World Marine 2 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-maurice
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-heather
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Heather
+        character_id: Open World Marine 1 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-heather
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-kimberly
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Kimberly
+        character_id: Open World Civilian 2 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-kimberly
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
@@ -1,0 +1,276 @@
+id: freeform-jungle
+name: Jungle Freeform Triage
+state:
+  unstructured: >
+    On an island jungle, your team runs over an IED as they are driving ATVs.
+  mission:
+    unstructured: Security patrol on an island jungle.
+    mission_type: Security patrol
+  environment:
+    sim_environment:
+      type: jungle
+      terrain: jungle
+      temperature: 88
+      humidity: 90
+      visibility: low
+      flora: lush
+    decision_environment:
+      unstructured: Your team runs over an IED as they are driving ATVs.
+      injury_triggers: explosion
+  threat_state:
+    unstructured: Your team just ran over an IED, so there are likely others in the area.
+    threats:
+      - {threat_type: IED activity, severity: substantial}
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Open World Marine 1 Male # Close to medic, on left
+      name: Brian
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+        He has a broken right shoulder and left leg, plus a right palm laceration.
+      demographics:
+        age: 28
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: UPSET
+        breathing: NORMAL
+        heart_rate: NORMAL
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: right shoulder
+          status: discoverable
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Laceration
+          location: right wrist
+          status: discoverable
+          severity: minor
+    - id: Open World Marine 2 Female # Just beyond Adam
+      name: Tiffany
+      unstructured: >
+        Patient is wearing allied military gear and is in the fetal position on her right side.
+        She calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in the fetal position on her right side.
+        She calls out to you for assistance and to draw attention to her injuries.
+        She has a left bicep puncture and shrapnel in her left calf.
+      demographics:
+        age: 31
+        sex: F
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: NORMAL
+        heart_rate: FAINT
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: moderate
+        - name: Shrapnel
+          location: left calf
+          status: discoverable
+          severity: substantial
+    - id: Open World Marine 3 Male # Just beyond Tiffany
+      name: Elijah
+      unstructured: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has multiple injuries, including a broken left shoulder and burns on both upper legs.
+      demographics:
+        age: 35
+        sex: M
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: VOICE
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Burn
+          location: right thigh
+          status: discoverable
+          severity: substantial
+        - name: Burn
+          location: left thigh
+          status: discoverable
+          severity: substantial
+    - id: Open World Marine 4 Male # Close to medic, on right
+      name: Adam
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He has multiple injuries, including a left neck puncture, right shin amputation, burned lower left leg, and shrapnel lodged in his face.
+      demographics:
+        age: 30
+        sex: M
+        race: Pacific Islander
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: false
+        avpu: UNRESPONSIVE
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: NONE
+        heart_rate: FAINT
+        spo2: 86 # "NONE" in sim
+      injuries:
+        - name: Shrapnel
+          location: left face
+          status: discoverable
+        - name: Burn
+          location: left calf
+          status: discoverable
+          severity: substantial
+        - name: Puncture
+          location: left neck
+          status: discoverable
+          severity: major
+        - name: Amputation
+          location: right calf
+          status: discoverable
+          severity: major
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-brian
+        action_type: TAG_CHARACTER
+        unstructured: Tag Brian
+        character_id: Open World Marine 1 Male
+        probe_id: tagging-probe
+        choice: tag-brian
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-tiffany
+        action_type: TAG_CHARACTER
+        unstructured: Tag Tiffany
+        character_id: Open World Marine 2 Female
+        probe_id: tagging-probe
+        choice: tag-tiffany
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-elijah
+        action_type: TAG_CHARACTER
+        unstructured: Tag Elijah
+        character_id: Open World Marine 3 Male
+        probe_id: tagging-probe
+        choice: tag-elijah
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-adam
+        action_type: TAG_CHARACTER
+        unstructured: Tag Adam
+        character_id: Open World Marine 4 Male
+        probe_id: tagging-probe
+        choice: tag-adam
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-brian
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Brian
+        character_id: Open World Marine 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-brian
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-tiffany
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Tiffany
+        character_id: Open World Marine 2 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-tiffany
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-elijah
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Elijah
+        character_id: Open World Marine 3 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-elijah
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-adam
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Adam
+        character_id: Open World Marine 4 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-adam
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
@@ -1,0 +1,294 @@
+id: freeform-submarine
+name: Submarine Freeform Triage
+state:
+  unstructured: >
+    You are the independent duty corpsman posted aboard a Virginia class nuclear submarine.
+    There was a fire onboard that caused injuries.  The fire is secured and the environment deemed safe, but there are injured sailors needing your help.
+  mission:
+    unstructured: You are on an intelligence gathering mission.  Your orders are to remain submerged at all costs.
+    mission_type: Intelligence gathering
+  environment:
+    sim_environment:
+      type: submarine
+      terrain: indoors
+      visibility: low
+      fauna: none
+      flora: none
+    decision_environment:
+      unstructured: There was a fire onboard that caused injuries.
+      injury_triggers: fire
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Navy Soldier 3 Male # Straight ahead in rear
+      name: Richard
+      unstructured: >
+        Patient is wearing allied military gear and is and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has puncture wounds on his left bicep and right thigh.
+      demographics:
+        age: 28
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: moderate
+        - name: Puncture
+          location: right thigh
+          status: discoverable
+          severity: moderate
+    - id: Navy Soldier 4 Female # Down the left hallway
+      name: Sarah
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position.
+        She calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position.
+        She calls out to you for assistance and to draw attention to her injuries.
+        She has a broken left leg and burns over both lower legs and the left side of her chest.
+      demographics:
+        age: 31
+        sex: F
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: right calf
+          status: discoverable
+        - name: Burn
+          location: left calf
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right calf
+          status: discoverable
+          severity: minor
+        - name: Burn
+          location: left chest
+          status: discoverable
+          severity: minor
+    - id: Navy Soldier 2 Male # First patient closest to medic
+      name: Matthew
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has multiple injuries, including a broken left shoulder and calf, a right shoulder puncture, and burns on his left calf and right forearm.
+      demographics:
+        age: 35
+        sex: M
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Puncture
+          location: right shoulder
+          status: discoverable
+          severity: substantial
+        - name: Burn
+          location: right calf
+          status: discoverable
+          severity: minor
+        - name: Burn
+          location: right forearm
+          status: discoverable
+          severity: minor
+    - id: Navy Soldier 1 Male # In intersection
+      name: Adam
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He is still and appears to have burns over much of his body.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He has a left neck puncture, and burns on both upper legs, both forearms, and his entire chest.
+      demographics:
+        age: 30
+        sex: M
+        race: Asian
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: false
+        avpu: UNRESPONSIVE
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 86 # "NONE" in sim
+      injuries:
+        - name: Puncture
+          location: left neck
+          status: discoverable
+          severity: major
+        - name: Burn
+          location: left thigh
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right thigh
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: left chest
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right chest
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: left forearm
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right forearm
+          status: discoverable
+          severity: moderate
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-richard
+        action_type: TAG_CHARACTER
+        unstructured: Tag Richard
+        character_id: Navy Soldier 3 Male
+        probe_id: tagging-probe
+        choice: tag-richard
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-sarah
+        action_type: TAG_CHARACTER
+        unstructured: Tag Sarah
+        character_id: Navy Soldier 4 Female
+        probe_id: tagging-probe
+        choice: tag-sarah
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-matthew
+        action_type: TAG_CHARACTER
+        unstructured: Tag Matthew
+        character_id: Navy Soldier 2 Male
+        probe_id: tagging-probe
+        choice: tag-matthew
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-adam
+        action_type: TAG_CHARACTER
+        unstructured: Tag Adam
+        character_id: Navy Soldier 1 Male
+        probe_id: tagging-probe
+        choice: tag-adam
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-richard
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Richard
+        character_id: Navy Soldier 3 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-richard
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-sarah
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Sarah
+        character_id: Navy Soldier 4 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-sarah
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-matthew
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Matthew
+        character_id: Navy Soldier 2 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-matthew
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-adam
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Adam
+        character_id: Navy Soldier 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-adam
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
@@ -1,0 +1,331 @@
+id: freeform-urban
+name: Urban Freeform Triage
+state:
+  unstructured: >
+    While executing your mission, your team came under fire from an adversary group.
+    The scene is secure and safe for you to enter, but there are injured unit members and civilians needing your help.
+  mission:
+    unstructured: The team was tasked with extraction of an asset from a location within the city.
+    mission_type: Extraction
+    civilian_presence: some
+  environment:
+    sim_environment:
+      type: urban
+      terrain: urban
+      lighting: normal
+      visibility: moderate
+      noise_ambient: noisy
+      flora: none
+      fauna: none
+    decision_environment:
+      unstructured: While executing your mission, your team came under fire from an adversary group.
+      injury_triggers: firearm
+      movement_restriction: unrestricted
+      sound_restriction: unrestricted
+  threat_state:
+    unstructured: There was recent gunfire from an adversary group.
+    threats:
+      - {threat_type: Gunfire, severity: low}
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Marine 1 Male # Near medic on right
+      name: William
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He appears to have multiple injuries with multiple blood pools.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He has multiple puncture injuries, including his neck, both thighs, and both sides of his stomach.
+      demographics:
+        age: 32
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: false
+        avpu: PAIN
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: RESTRICTED
+        heart_rate: FAINT
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: right thigh
+          status: discoverable
+          severity: major
+        - name: Puncture
+          location: left thigh
+          status: discoverable
+          severity: major
+        - name: Puncture
+          location: left neck
+          status: discoverable
+          severity: major
+        - name: Puncture
+          location: left stomach
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: right stomach
+          status: discoverable
+          severity: minor
+    - id: Marine 2 Male # TBD
+      name: Jeff
+      unstructured: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has a broken left shoulder and right thigh puncture.
+      demographics:
+        age: 27
+        sex: M
+        race: Asian
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Puncture
+          location: right thigh
+          status: discoverable
+          severity: substantial
+    - id: Marine 3 Male # In the storage area with smooth jazz music
+      name: David
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has two broken legs and a right stomach puncture.
+      demographics:
+        age: 33
+        sex: M
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Broken Bone
+          location: right calf
+          status: discoverable
+        - name: Puncture
+          location: right stomach
+          status: discoverable
+          severity: substantial
+    - id: Marine 4 Male # Near medic on left
+      name: Christopher
+      unstructured: >
+        Patient is wearing allied military gear and is sitting on the ground.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He has puncture wounds in his left shoulder and bicep.
+      demographics:
+        age: 25
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: left shoulder
+          status: discoverable
+          severity: moderate
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: minor
+    - id: Civilian 1 Female # On street beyond storage area
+      name: Allison
+      unstructured: >
+        Patient is wearing civilian gear and is in a supine position on her back.
+        She calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing civilian gear and is in a supine position on her back.
+        She calls out to you for assistance and to draw attention to her injuries.
+        She has a puncture would on her left bicep and a broken left leg and right shoulder.
+      demographics:
+        age: 41
+        sex: F
+        race: Asian
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: moderate
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-william
+        action_type: TAG_CHARACTER
+        unstructured: Tag William
+        character_id: Marine 1 Male
+        probe_id: tagging-probe
+        choice: tag-william
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-jeff
+        action_type: TAG_CHARACTER
+        unstructured: Tag Jeff
+        character_id: Marine 2 Male
+        probe_id: tagging-probe
+        choice: tag-jeff
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-david
+        action_type: TAG_CHARACTER
+        unstructured: Tag David
+        character_id: Marine 3 Male
+        probe_id: tagging-probe
+        choice: tag-david
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-christopher
+        action_type: TAG_CHARACTER
+        unstructured: Tag Christopher
+        character_id: Marine 4 Male
+        probe_id: tagging-probe
+        choice: tag-christopher
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-allison
+        action_type: TAG_CHARACTER
+        unstructured: Tag Allison
+        character_id: Civilian 1 Female
+        probe_id: tagging-probe
+        choice: tag-allison
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-william
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on William
+        character_id: Marine 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-william
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-jeff
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Jeff
+        character_id: Marine 2 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-jeff
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-david
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on David
+        character_id: Marine 3 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-david
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-christopher
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Christopher
+        character_id: Marine 4 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-christopher
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-allison
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Allison
+        character_id: Civilian 1 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-allison
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
@@ -1,0 +1,270 @@
+id: freeform-desert
+name: Desert Freeform Triage
+state:
+  unstructured: >
+    In a rural desert town, you are the medic for a small unit.  A local militia attacked your team and local civilians.
+    The scene is secure, but there are injured teammates and civilians who need your help.
+  environment:
+    sim_environment:
+      type: desert
+      weather: clear
+      lighting: bright
+      visibility: excellent
+      noise_peak: noisy
+      temperature: 92
+      fauna: normal
+    decision_environment:
+      unstructured: A local militia attacked your team and local civilians.
+      injury_triggers: firearm
+  threat_state:
+    unstructured: There was recent gunfire from a local militia.
+    threats:
+      - {threat_type: Gunfire, severity: moderate}
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Open World Civilian 1 Male # Right in front of medic at start
+      name: William
+      unstructured: >
+        Patient is wearing civilian gear and is sitting on the ground.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing civilian gear and is sitting on the ground.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+        He has broken left shoulder and puncture wound in the right shoulder.
+      demographics:
+        age: 32
+        sex: M
+        race: White
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false # TBD Should be true, with only shoulder injuries?
+        mental_status: UPSET
+        breathing: NORMAL
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Puncture
+          location: right shoulder
+          status: discoverable
+          severity: major
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+    - id: Open World Marine 2 Male # Beyond William in the next room
+      name: Maurice
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has a broken right leg and left wrist amputation.
+      demographics:
+        age: 27
+        sex: M
+        race: Hispanic
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Broken Bone
+          location: right calf
+          status: discoverable
+        - name: Amputation
+          location: left wrist
+          status: discoverable
+          severity: major
+    - id: Open World Marine 1 Female # In room to the right, standing
+      name: Heather
+      unstructured: >
+        Patient is wearing allied military gear and is standing facing the wall.
+        She occasionally calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is standing facing the wall.
+        She occasionally calls out to you for assistance and to draw attention to her injuries.
+        She has a punctured left bicep and right forearm laceration.
+      demographics:
+        age: 33
+        sex: F
+        race: Pacific Islander
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: true
+        mental_status: UPSET
+        breathing: NORMAL
+        heart_rate: NORMAL
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Laceration
+          location: right forearm
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: minor
+    - id: Open World Civilian 2 Female # In room to the right, supine
+      name: Kimberly
+      unstructured: >
+        Patient is wearing civilian gear and is in a supine position on her right side.
+        She appears to have multiple injuries with multiple blood pools.
+      unstructured_postassess: >
+        Patient is wearing civilian gear and is in a supine position on her back.
+        She has multiple puncture injuries to her left bicep, left side, and left stomach, as well as a right calf laceration and face shrapnel.
+      demographics:
+        age: 38
+        sex: F
+        race: White
+      vitals:
+        conscious: false
+        avpu: PAIN
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: left side
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: left stomach
+          status: discoverable
+          severity: substantial
+        - name: Laceration
+          location: right calf
+          status: discoverable
+          severity: substantial
+        - name: Shrapnel
+          location: left face
+          status: discoverable
+          severity: moderate
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-william
+        action_type: TAG_CHARACTER
+        unstructured: Tag William
+        character_id: Open World Civilian 1 Male
+        probe_id: tagging-probe
+        choice: tag-william
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-maurice
+        action_type: TAG_CHARACTER
+        unstructured: Tag Maurice
+        character_id: Open World Marine 2 Male
+        probe_id: tagging-probe
+        choice: tag-maurice
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-heather
+        action_type: TAG_CHARACTER
+        unstructured: Tag Heather
+        character_id: Open World Marine 1 Female
+        probe_id: tagging-probe
+        choice: tag-heather
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-kimberly
+        action_type: TAG_CHARACTER
+        unstructured: Tag Kimberly
+        character_id: Open World Civilian 2 Female
+        probe_id: tagging-probe
+        choice: tag-kimberly
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-william
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on William
+        character_id: Open World Civilian 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-william
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-maurice
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Maurice
+        character_id: Open World Marine 2 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-maurice
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-heather
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Heather
+        character_id: Open World Marine 1 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-heather
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-kimberly
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Kimberly
+        character_id: Open World Civilian 2 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-kimberly
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
@@ -1,0 +1,276 @@
+id: freeform-jungle
+name: Jungle Freeform Triage
+state:
+  unstructured: >
+    On an island jungle, your team runs over an IED as they are driving ATVs.
+  mission:
+    unstructured: Security patrol on an island jungle.
+    mission_type: Security patrol
+  environment:
+    sim_environment:
+      type: jungle
+      terrain: jungle
+      temperature: 88
+      humidity: 90
+      visibility: low
+      flora: lush
+    decision_environment:
+      unstructured: Your team runs over an IED as they are driving ATVs.
+      injury_triggers: explosion
+  threat_state:
+    unstructured: Your team just ran over an IED, so there are likely others in the area.
+    threats:
+      - {threat_type: IED activity, severity: substantial}
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Open World Marine 1 Male # Close to medic, on left
+      name: Brian
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He occasionally calls out to you for assistance and to draw attention to his injuries.
+        He has a broken right shoulder and left leg, plus a right palm laceration.
+      demographics:
+        age: 28
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: UPSET
+        breathing: NORMAL
+        heart_rate: NORMAL
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: right shoulder
+          status: discoverable
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Laceration
+          location: right wrist
+          status: discoverable
+          severity: minor
+    - id: Open World Marine 2 Female # Just beyond Adam
+      name: Tiffany
+      unstructured: >
+        Patient is wearing allied military gear and is in the fetal position on her right side.
+        She calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in the fetal position on her right side.
+        She calls out to you for assistance and to draw attention to her injuries.
+        She has a left bicep puncture and shrapnel in her left calf.
+      demographics:
+        age: 31
+        sex: F
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: NORMAL
+        heart_rate: FAINT
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: moderate
+        - name: Shrapnel
+          location: left calf
+          status: discoverable
+          severity: substantial
+    - id: Open World Marine 3 Male # Just beyond Tiffany
+      name: Elijah
+      unstructured: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has multiple injuries, including a broken left shoulder and burns on both upper legs.
+      demographics:
+        age: 35
+        sex: M
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: VOICE
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Burn
+          location: right thigh
+          status: discoverable
+          severity: substantial
+        - name: Burn
+          location: left thigh
+          status: discoverable
+          severity: substantial
+    - id: Open World Marine 4 Male # Close to medic, on right
+      name: Adam
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He has multiple injuries, including a left neck puncture, right shin amputation, burned lower left leg, and shrapnel lodged in his face.
+      demographics:
+        age: 30
+        sex: M
+        race: Pacific Islander
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: false
+        avpu: UNRESPONSIVE
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: NONE
+        heart_rate: FAINT
+        spo2: 86 # "NONE" in sim
+      injuries:
+        - name: Shrapnel
+          location: left face
+          status: discoverable
+        - name: Burn
+          location: left calf
+          status: discoverable
+          severity: substantial
+        - name: Puncture
+          location: left neck
+          status: discoverable
+          severity: major
+        - name: Amputation
+          location: right calf
+          status: discoverable
+          severity: major
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-brian
+        action_type: TAG_CHARACTER
+        unstructured: Tag Brian
+        character_id: Open World Marine 1 Male
+        probe_id: tagging-probe
+        choice: tag-brian
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-tiffany
+        action_type: TAG_CHARACTER
+        unstructured: Tag Tiffany
+        character_id: Open World Marine 2 Female
+        probe_id: tagging-probe
+        choice: tag-tiffany
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-elijah
+        action_type: TAG_CHARACTER
+        unstructured: Tag Elijah
+        character_id: Open World Marine 3 Male
+        probe_id: tagging-probe
+        choice: tag-elijah
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-adam
+        action_type: TAG_CHARACTER
+        unstructured: Tag Adam
+        character_id: Open World Marine 4 Male
+        probe_id: tagging-probe
+        choice: tag-adam
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-brian
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Brian
+        character_id: Open World Marine 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-brian
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-tiffany
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Tiffany
+        character_id: Open World Marine 2 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-tiffany
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-elijah
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Elijah
+        character_id: Open World Marine 3 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-elijah
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-adam
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Adam
+        character_id: Open World Marine 4 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-adam
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
@@ -1,0 +1,294 @@
+id: freeform-submarine
+name: Submarine Freeform Triage
+state:
+  unstructured: >
+    You are the independent duty corpsman posted aboard a Virginia class nuclear submarine.
+    There was a fire onboard that caused injuries.  The fire is secured and the environment deemed safe, but there are injured sailors needing your help.
+  mission:
+    unstructured: You are on an intelligence gathering mission.  Your orders are to remain submerged at all costs.
+    mission_type: Intelligence gathering
+  environment:
+    sim_environment:
+      type: submarine
+      terrain: indoors
+      visibility: low
+      fauna: none
+      flora: none
+    decision_environment:
+      unstructured: There was a fire onboard that caused injuries.
+      injury_triggers: fire
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Navy Soldier 3 Male # Straight ahead in rear
+      name: Richard
+      unstructured: >
+        Patient is wearing allied military gear and is and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has puncture wounds on his left bicep and right thigh.
+      demographics:
+        age: 28
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: moderate
+        - name: Puncture
+          location: right thigh
+          status: discoverable
+          severity: moderate
+    - id: Navy Soldier 4 Female # Down the left hallway
+      name: Sarah
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position.
+        She calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position.
+        She calls out to you for assistance and to draw attention to her injuries.
+        She has a broken left leg and burns over both lower legs and the left side of her chest.
+      demographics:
+        age: 31
+        sex: F
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: right calf
+          status: discoverable
+        - name: Burn
+          location: left calf
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right calf
+          status: discoverable
+          severity: minor
+        - name: Burn
+          location: left chest
+          status: discoverable
+          severity: minor
+    - id: Navy Soldier 2 Male # First patient closest to medic
+      name: Matthew
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has multiple injuries, including a broken left shoulder and calf, a right shoulder puncture, and burns on his left calf and right forearm.
+      demographics:
+        age: 35
+        sex: M
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Puncture
+          location: right shoulder
+          status: discoverable
+          severity: substantial
+        - name: Burn
+          location: right calf
+          status: discoverable
+          severity: minor
+        - name: Burn
+          location: right forearm
+          status: discoverable
+          severity: minor
+    - id: Navy Soldier 1 Male # In intersection
+      name: Adam
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He is still and appears to have burns over much of his body.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He has a left neck puncture, and burns on both upper legs, both forearms, and his entire chest.
+      demographics:
+        age: 30
+        sex: M
+        race: Asian
+        military_disposition: Allied US
+        military_branch: US Navy
+      vitals:
+        conscious: false
+        avpu: UNRESPONSIVE
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 86 # "NONE" in sim
+      injuries:
+        - name: Puncture
+          location: left neck
+          status: discoverable
+          severity: major
+        - name: Burn
+          location: left thigh
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right thigh
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: left chest
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right chest
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: left forearm
+          status: discoverable
+          severity: moderate
+        - name: Burn
+          location: right forearm
+          status: discoverable
+          severity: moderate
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-richard
+        action_type: TAG_CHARACTER
+        unstructured: Tag Richard
+        character_id: Navy Soldier 3 Male
+        probe_id: tagging-probe
+        choice: tag-richard
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-sarah
+        action_type: TAG_CHARACTER
+        unstructured: Tag Sarah
+        character_id: Navy Soldier 4 Female
+        probe_id: tagging-probe
+        choice: tag-sarah
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-matthew
+        action_type: TAG_CHARACTER
+        unstructured: Tag Matthew
+        character_id: Navy Soldier 2 Male
+        probe_id: tagging-probe
+        choice: tag-matthew
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-adam
+        action_type: TAG_CHARACTER
+        unstructured: Tag Adam
+        character_id: Navy Soldier 1 Male
+        probe_id: tagging-probe
+        choice: tag-adam
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-richard
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Richard
+        character_id: Navy Soldier 3 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-richard
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-sarah
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Sarah
+        character_id: Navy Soldier 4 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-sarah
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-matthew
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Matthew
+        character_id: Navy Soldier 2 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-matthew
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-adam
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Adam
+        character_id: Navy Soldier 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-adam
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
@@ -1,0 +1,331 @@
+id: freeform-urban
+name: Urban Freeform Triage
+state:
+  unstructured: >
+    While executing your mission, your team came under fire from an adversary group.
+    The scene is secure and safe for you to enter, but there are injured unit members and civilians needing your help.
+  mission:
+    unstructured: The team was tasked with extraction of an asset from a location within the city.
+    mission_type: Extraction
+    civilian_presence: some
+  environment:
+    sim_environment:
+      type: urban
+      terrain: urban
+      lighting: normal
+      visibility: moderate
+      noise_ambient: noisy
+      flora: none
+      fauna: none
+    decision_environment:
+      unstructured: While executing your mission, your team came under fire from an adversary group.
+      injury_triggers: firearm
+      movement_restriction: unrestricted
+      sound_restriction: unrestricted
+  threat_state:
+    unstructured: There was recent gunfire from an adversary group.
+    threats:
+      - {threat_type: Gunfire, severity: low}
+  supplies:
+    - { type: Hemostatic gauze, quantity: 999 }
+    - { type: Tourniquet, quantity: 999 }
+    - { type: Pressure bandage, quantity: 999 }
+    - { type: Decompression Needle, quantity: 999 }
+    - { type: Nasopharyngeal airway, quantity: 999 }
+    - { type: Pulse Oximeter, quantity: 1, reusable: True }
+    - { type: Pain Medications, quantity: 999 }
+    - { type: Splint, quantity: 999 }
+    - { type: Blood, quantity: 999 }
+    - { type: Burn Dressing, quantity: 999 }
+  characters:
+    - id: Marine 1 Male # Near medic on right
+      name: William
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He appears to have multiple injuries with multiple blood pools.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his right side.
+        He has multiple puncture injuries, including his neck, both thighs, and both sides of his stomach.
+      demographics:
+        age: 32
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: false
+        avpu: PAIN
+        ambulatory: false
+        mental_status: UNRESPONSIVE
+        breathing: RESTRICTED
+        heart_rate: FAINT
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: right thigh
+          status: discoverable
+          severity: major
+        - name: Puncture
+          location: left thigh
+          status: discoverable
+          severity: major
+        - name: Puncture
+          location: left neck
+          status: discoverable
+          severity: major
+        - name: Puncture
+          location: left stomach
+          status: discoverable
+          severity: minor
+        - name: Puncture
+          location: right stomach
+          status: discoverable
+          severity: minor
+    - id: Marine 2 Male # TBD
+      name: Jeff
+      unstructured: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has a broken left shoulder and right thigh puncture.
+      demographics:
+        age: 27
+        sex: M
+        race: Asian
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Puncture
+          location: right thigh
+          status: discoverable
+          severity: substantial
+    - id: Marine 3 Male # In the storage area with smooth jazz music
+      name: David
+      unstructured: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is in a supine position on his back.
+        He calls out to you for assistance and to draw attention to his injuries.
+        He has two broken legs and a right stomach puncture.
+      demographics:
+        age: 33
+        sex: M
+        race: Black
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Broken Bone
+          location: right calf
+          status: discoverable
+        - name: Puncture
+          location: right stomach
+          status: discoverable
+          severity: substantial
+    - id: Marine 4 Male # Near medic on left
+      name: Christopher
+      unstructured: >
+        Patient is wearing allied military gear and is sitting on the ground.
+      unstructured_postassess: >
+        Patient is wearing allied military gear and is sitting on the ground.
+        He has puncture wounds in his left shoulder and bicep.
+      demographics:
+        age: 25
+        sex: M
+        race: White
+        military_disposition: Allied US
+        military_branch: US Marine Corps
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 90 # "LOW" in sim
+      injuries:
+        - name: Puncture
+          location: left shoulder
+          status: discoverable
+          severity: moderate
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: minor
+    - id: Civilian 1 Female # On street beyond storage area
+      name: Allison
+      unstructured: >
+        Patient is wearing civilian gear and is in a supine position on her back.
+        She calls out to you for assistance and to draw attention to her injuries.
+      unstructured_postassess: >
+        Patient is wearing civilian gear and is in a supine position on her back.
+        She calls out to you for assistance and to draw attention to her injuries.
+        She has a puncture would on her left bicep and a broken left leg and right shoulder.
+      demographics:
+        age: 41
+        sex: F
+        race: Asian
+      vitals:
+        conscious: true
+        avpu: ALERT
+        ambulatory: false
+        mental_status: AGONY
+        breathing: FAST
+        heart_rate: FAST
+        spo2: 97 # "NORMAL" in sim
+      injuries:
+        - name: Broken Bone
+          location: left shoulder
+          status: discoverable
+        - name: Broken Bone
+          location: left calf
+          status: discoverable
+        - name: Puncture
+          location: left bicep
+          status: discoverable
+          severity: moderate
+
+scenes:
+  - index: 0
+    end_scene_allowed: true
+    restricted_actions:
+      - DIRECT_MOBILE_CHARACTERS
+      - SEARCH
+      - MOVE_TO_EVAC
+    action_mapping:
+      - action_id: tag-william
+        action_type: TAG_CHARACTER
+        unstructured: Tag William
+        character_id: Marine 1 Male
+        probe_id: tagging-probe
+        choice: tag-william
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-jeff
+        action_type: TAG_CHARACTER
+        unstructured: Tag Jeff
+        character_id: Marine 2 Male
+        probe_id: tagging-probe
+        choice: tag-jeff
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-david
+        action_type: TAG_CHARACTER
+        unstructured: Tag David
+        character_id: Marine 3 Male
+        probe_id: tagging-probe
+        choice: tag-david
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-christopher
+        action_type: TAG_CHARACTER
+        unstructured: Tag Christopher
+        character_id: Marine 4 Male
+        probe_id: tagging-probe
+        choice: tag-christopher
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: tag-allison
+        action_type: TAG_CHARACTER
+        unstructured: Tag Allison
+        character_id: Civilian 1 Female
+        probe_id: tagging-probe
+        choice: tag-allison
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: sitrep
+        action_type: SITREP
+        unstructured: Ask for a SITREP from all patients
+        probe_id: action-probe
+        choice: sitrep
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: check-vitals
+        action_type: CHECK_ALL_VITALS
+        unstructured: Check a patient's vital signs
+        probe_id: action-probe
+        choice: check-all-vitals
+        repeatable: true
+        conditions:
+          elapsed_time_gt: 30000000
+
+      - action_id: treat-william
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on William
+        character_id: Marine 1 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-william
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-jeff
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Jeff
+        character_id: Marine 2 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-jeff
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-david
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on David
+        character_id: Marine 3 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-david
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-christopher
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Christopher
+        character_id: Marine 4 Male
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-christopher
+        conditions:
+          elapsed_time_gt: 30000000
+      - action_id: treat-allison
+        action_type: APPLY_TREATMENT
+        unstructured: Treat an injury on Allison
+        character_id: Civilian 1 Female
+        repeatable: true
+        probe_id: action-probe
+        choice: treat-allison
+        conditions:
+          elapsed_time_gt: 30000000
+    transitions:
+      elapsed_time_gt: 30000000
+  - index: 1
+    end_scene_allowed: true
+    action_mapping: []


### PR DESCRIPTION
There are eight scenarios-- four soartech and four adept-- but the scenarios are identical.
These will be run as part of an `eval` session, but no communication with TA1 will happen for these scenarios (as there are no probes or probe responses).  Session alignment will be logged in history always as 0.5, and can be ignored.

To test, run an evaluation session with the TA3 client (or a TA2 ADM) and ensure that eight JSON files are created with names like, e.g., `freeform-desert-adept-high-Apr04-11.34.46.json`.