### PR TITLE
ITM-247: Added final_scene flag to indicate final scene in a scenario

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -852,6 +852,9 @@ components:
           minimum: 0
         state:
           $ref: "#/components/schemas/State"
+        final_scene:
+          type: boolean
+          description: Whether this is the final scene in the scenario
         end_scene_allowed:
           type: boolean
           description: Whether ADMs can explicitly end the scene

--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -108,11 +108,17 @@ class ITMScenario:
 
 
     def change_scene(self, next_scene, had_transitions):
+        if self.isd.current_scene.final_scene:
+            self.isd.current_scene.state = None # Supports single-scenario sessions
+            self.session.end_scenario()
+            return
+
         if (next_scene >= len(self.isd.scenes)):
             if had_transitions:
-                #TODO: Address this and/or End the scenario
-                print("--> WARNING: scene configuration issue; final scene should have no transitions to the next scene")
+                print("--> WARNING: scene configuration issue: invalid scene index; ending session.")
+                self.session.end_scenario()
             return
+
         previous_scene_characters = self.isd.current_scene.state.characters
         self.isd.current_scene_index = next_scene
         self.isd.current_scene = self.isd.scenes[next_scene]

--- a/swagger_server/itm/itm_scenario_reader.py
+++ b/swagger_server/itm/itm_scenario_reader.py
@@ -86,6 +86,7 @@ class ITMScenarioReader:
         scene = Scene(
             index=scene_data['index'],
             state=state,
+            final_scene=scene_data.get('final_scene', False),
             end_scene_allowed=scene_data['end_scene_allowed'],
             persist_characters=scene_data.get('persist_characters', False),
             probe_config=None, # Not used by TA3

--- a/swagger_server/itm/itm_scene.py
+++ b/swagger_server/itm/itm_scene.py
@@ -20,6 +20,7 @@ class ITMScene:
         self.index = scene.index
         self.state :State = scene.state # State updates for the scene, including a new cast of characters
         self.end_scene_allowed = scene.end_scene_allowed
+        self.final_scene = scene.final_scene
         self.persist_characters = scene.persist_characters
         self.action_mappings :List[ActionMapping] = scene.action_mapping
         for mapping in self.action_mappings:

--- a/swagger_server/models/scene.py
+++ b/swagger_server/models/scene.py
@@ -21,13 +21,15 @@ class Scene(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, index: int=None, state: State=None, end_scene_allowed: bool=None, persist_characters: bool=None, probe_config: List[ProbeConfig]=None, tagging: Tagging=None, action_mapping: List[ActionMapping]=None, restricted_actions: List[ActionTypeEnum]=None, transition_semantics: SemanticTypeEnum=None, transitions: Conditions=None):  # noqa: E501
+    def __init__(self, index: int=None, state: State=None, final_scene: bool=None, end_scene_allowed: bool=None, persist_characters: bool=None, probe_config: List[ProbeConfig]=None, tagging: Tagging=None, action_mapping: List[ActionMapping]=None, restricted_actions: List[ActionTypeEnum]=None, transition_semantics: SemanticTypeEnum=None, transitions: Conditions=None):  # noqa: E501
         """Scene - a model defined in Swagger
 
         :param index: The index of this Scene.  # noqa: E501
         :type index: int
         :param state: The state of this Scene.  # noqa: E501
         :type state: State
+        :param final_scene: The final_scene of this Scene.  # noqa: E501
+        :type final_scene: bool
         :param end_scene_allowed: The end_scene_allowed of this Scene.  # noqa: E501
         :type end_scene_allowed: bool
         :param persist_characters: The persist_characters of this Scene.  # noqa: E501
@@ -48,6 +50,7 @@ class Scene(Model):
         self.swagger_types = {
             'index': int,
             'state': State,
+            'final_scene': bool,
             'end_scene_allowed': bool,
             'persist_characters': bool,
             'probe_config': List[ProbeConfig],
@@ -61,6 +64,7 @@ class Scene(Model):
         self.attribute_map = {
             'index': 'index',
             'state': 'state',
+            'final_scene': 'final_scene',
             'end_scene_allowed': 'end_scene_allowed',
             'persist_characters': 'persist_characters',
             'probe_config': 'probe_config',
@@ -72,6 +76,7 @@ class Scene(Model):
         }
         self._index = index
         self._state = state
+        self._final_scene = final_scene
         self._end_scene_allowed = end_scene_allowed
         self._persist_characters = persist_characters
         self._probe_config = probe_config
@@ -137,6 +142,29 @@ class Scene(Model):
         """
 
         self._state = state
+
+    @property
+    def final_scene(self) -> bool:
+        """Gets the final_scene of this Scene.
+
+        Whether this is the final scene in the scenario  # noqa: E501
+
+        :return: The final_scene of this Scene.
+        :rtype: bool
+        """
+        return self._final_scene
+
+    @final_scene.setter
+    def final_scene(self, final_scene: bool):
+        """Sets the final_scene of this Scene.
+
+        Whether this is the final scene in the scenario  # noqa: E501
+
+        :param final_scene: The final_scene of this Scene.
+        :type final_scene: bool
+        """
+
+        self._final_scene = final_scene
 
     @property
     def end_scene_allowed(self) -> bool:


### PR DESCRIPTION
See [ITM-247](https://nextcentury.atlassian.net/browse/ITM-247) for a discussion of possible solutions to this issue.  Feel free to weigh in on other solutions.  I chose this approach because it's simple configuration, backwardly-compatible, but still supports "short cuts" to the end of a scenario (by using the old "dummy scene" configuration.

To test, rename [metrics-adept-eval-desert.yaml.txt](https://github.com/NextCenturyCorporation/itm-evaluation-server/files/14952437/metrics-adept-eval-desert.yaml.txt) to `metrics-adept-eval-desert.yaml`, place it in `swagger_server/itm/data/metrics/scenarios/`, and run:
- `python itm_minimal_runner.py --adm_name foobar --session adept --scenario MetricsEval.MD5-Desert`

You can also run the following to test full backward-compatibility:
- `python itm_minimal_runner.py --adm_name foobar --session adept`

Feel free to play around with re-introducing the dummy scene (see the diff at the end of the file) and make certain action paths specify a `next_scene` of 7 like it used to.