### PR TITLE
ITM-300: add adm_profile optional session parameter

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -24,8 +24,16 @@ paths:
       parameters:
         - name: adm_name
           in: query
-          description: A self-assigned ADM name.  Can add authentication later.
+          description: A self-assigned ADM name.
           required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: adm_profile
+          in: query
+          description: a profile of the ADM in terms of its alignment strategy
+          required: false
           style: form
           explode: true
           schema:

--- a/swagger_server/controllers/itm_ta2_eval_controller.py
+++ b/swagger_server/controllers/itm_ta2_eval_controller.py
@@ -115,7 +115,7 @@ def start_session(adm_name, session_type, adm_profile=None, kdma_training=False,
 
     :param adm_name: A self-assigned ADM name.
     :type adm_name: str
-    :param session_type: the type of session to start `test`, `eval`, or a TA1 name)
+    :param session_type: the type of session to start (`test`, `eval`, or a TA1 name)
     :type session_type: str
     :param adm_profile: a profile of the ADM in terms of its alignment strategy
     :type adm_profile: str

--- a/swagger_server/controllers/itm_ta2_eval_controller.py
+++ b/swagger_server/controllers/itm_ta2_eval_controller.py
@@ -108,18 +108,20 @@ def _reclaim_old_session():
             session_mapping.pop(session_id)             # From both places
             return ITMSession()
 
-def start_session(adm_name, session_type, kdma_training=None, max_scenarios=None):  # noqa: E501
+def start_session(adm_name, session_type, adm_profile=None, kdma_training=False, max_scenarios=None):  # noqa: E501
     """Start a new session
 
     Get unique session id for grouping answers from a collection of scenarios/probes together # noqa: E501
 
-    :param adm_name: A self-assigned ADM name.  Can add authentication later.
+    :param adm_name: A self-assigned ADM name.
     :type adm_name: str
-    :param session_type: the type of session to start (&#x60;test&#x60;, &#x60;eval&#x60;, or a TA1 name)
+    :param session_type: the type of session to start `test`, `eval`, or a TA1 name)
     :type session_type: str
+    :param adm_profile: a profile of the ADM in terms of its alignment strategy
+    :type adm_profile: str
     :param kdma_training: whether or not this is a training session with TA2
     :type kdma_training: bool
-    :param max_scenarios: the maximum number of scenarios requested, supported only in &#x60;test&#x60; sessions
+    :param max_scenarios: the maximum number of scenarios requested, supported only in `test` sessions
     :type max_scenarios: int
 
     :rtype: str
@@ -149,6 +151,7 @@ def start_session(adm_name, session_type, kdma_training=None, max_scenarios=None
         adm_name=adm_name,
         session_type=session_type,
         kdma_training=kdma_training,
+        adm_profile=adm_profile if adm_profile != 'None' else None,
         max_scenarios=max_scenarios
     )
     session_mapping[session_id] = {"adm_name": adm_name, "last_accessed": time.time()}

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -35,6 +35,7 @@ class ITMSession:
         """
         self.session_id = None
         self.adm_name = ''
+        self.adm_profile = ''
         self.time_started = 0
         self.time_elapsed_realtime = 0
 
@@ -244,8 +245,8 @@ class ITMSession:
         if self.kdma_training:
             return 'No alignment target in training sessions', 400
 
-        if self.session_type == 'eval' and 'base' in self.adm_name:
-            print('\033[92mWARNING!  An ADM with "base" in the name is requesting an alignment target during evaluation.\033[00m')
+        if self.session_type == 'eval' and 'base' in self.adm_profile:
+            print('\033[92mWARNING!  An ADM with "base" in the ADM profile is requesting an alignment target during evaluation.\033[00m')
 
         return self.itm_scenario.alignment_target
 
@@ -321,7 +322,7 @@ class ITMSession:
 
             self.history.add_history(
                 "Start Scenario",
-                {"session_id": self.session_id, "adm_name": self.adm_name},
+                {"session_id": self.session_id, "adm_name": self.adm_name, "adm_profile" : self.adm_profile},
                 scenario.to_dict())
             print(f"--> Scenario '{self.itm_scenario.id}' starting.")
 
@@ -360,13 +361,15 @@ class ITMSession:
         return Scenario(session_complete=True, id='', name='',
                         scenes=None, state=None)
 
-    def start_session(self, adm_name: str, session_type: str, kdma_training: bool, max_scenarios=None) -> str:
+    def start_session(self, adm_name: str, session_type: str, adm_profile: str, kdma_training: bool, max_scenarios=None) -> str:
         """
         Start a new session.
 
         Args:
-            adm_name: The adm name associated with the scenario.
+            adm_name: The ADM name associated with the session.
             session_type: The type of scenarios either soartech, adept, or eval
+            adm_profile: a profile of the ADM in terms of its alignment strategy
+            kdma_training: whether or not this is a training session with TA2
             max_scenarios: The max number of scenarios presented during the session
 
         Returns:
@@ -392,6 +395,7 @@ class ITMSession:
 
         self.kdma_training = kdma_training
         self.adm_name = adm_name
+        self.adm_profile = adm_profile if adm_profile else 'Unspecified'
         self.itm_scenarios = []
         self.session_type = session_type
         self.history.clear_history()
@@ -412,6 +416,7 @@ class ITMSession:
                 "Start Session",
                 {"session_id": self.session_id,
                 "adm_name": self.adm_name,
+                "adm_profile": self.adm_profile,
                 "session_type": session_type},
                 self.session_id)
 


### PR DESCRIPTION
Currently, just logs the profile to history.  A new ticket would expand the notion of ADM profile for multiple KDMAs, which will probably entail some discussion down the line.

Test using the corresponding [ITM-300](https://github.com/NextCenturyCorporation/itm-evaluation-client/tree/ITM-300) client branch.

[ITM-300]: https://nextcentury.atlassian.net/browse/ITM-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ