### PR TITLE
Return 400 error code for restricted actions.

### DIFF
--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -136,6 +136,11 @@ class ITMActionHandler:
 
         if action.parameters and not isinstance(action.parameters, dict):
             return False, 'Malformed Action: Invalid Parameter Structure', 400
+
+        if action.action_type in self.current_scene.restricted_actions or \
+            action.action_type == ActionTypeEnum.END_SCENE and not self.current_scene.end_scene_allowed:
+            return False, 'Invalid Action: action restricted', 400
+
         # lookup character id in state
         character = None
         if action.character_id:


### PR DESCRIPTION
To test, what I did was add
```
        if random.randint(1, 3) == 3:
            random_action = Action(action_id='foobar', action_type='END_SCENE')
```
just before `if (paths["enabled"]):` in `itm_minimal_runner.py` on `development`.  Then I ran the minimal runner:
- `python itm_minimal_runner.py --session adept --name foobar --scenario MetricsEval.MD5-Desert`

Then I repeated it, changing `END_SCENE` to `CHECK_RESPIRATION`.

**NOTE**: ADMs can still take an action where they use the `action_id` from `get_available_actions`, then send whatever the heck they want for the `action_type`, `parameters`, etc.  As long as the action is well-formed and isn't restricted, the server will allow it.  In other words, it doesn't check that the incoming action matches the configured action with the specified `action_id`.  I guess that could be another ticket, but low priority.