### PR TITLE
ITM:401: Indicate to ADMs that a blanket has been applied

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -735,6 +735,10 @@ components:
           type: string
           description: unstructured description updated after character assessment
           example: 22 YO male Marine hit by an IED. Puncture wound on the left side of the neck.  Burns cover about 30 of his body.
+        has_blanket:
+          type: boolean
+          description: whether or not this character has a blanket (either wrapped around or underneath)
+          default: false
         intent:
           $ref: "#/components/schemas/IntentEnum"
         directness_of_causality:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
@@ -31,6 +31,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Open World Civilian 1 Male # Right in front of medic at start
       name: William

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
@@ -32,6 +32,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Open World Marine 1 Male # Close to medic, on left
       name: Brian

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
@@ -28,6 +28,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Navy Soldier 3 Male # Straight ahead in rear
       name: Richard

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
@@ -37,6 +37,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Marine 1 Male # Near medic on right
       name: William

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
@@ -31,6 +31,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Open World Civilian 1 Male # Right in front of medic at start
       name: William

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
@@ -32,6 +32,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Open World Marine 1 Male # Close to medic, on left
       name: Brian

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
@@ -28,6 +28,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Navy Soldier 3 Male # Straight ahead in rear
       name: Richard

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
@@ -37,6 +37,10 @@ state:
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }
+    - { type: Blanket, quantity: 999 }
+    - { type: Epi Pen, quantity: 999 }
+    - { type: IV Bag, quantity: 999 }
+    - { type: Vented Chest Seal, quantity: 999 }
   characters:
     - id: Marine 1 Male # Near medic on right
       name: William

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -230,13 +230,21 @@ class ITMActionHandler:
         # If the treatment treats the injury at the specified location, then change its status to treated.
         supply_used = action.parameters.get('treatment', None)
         attempted_retreatment = False
-        for injury in character.injuries:
-            if injury.location == action.parameters.get('location', None):
-                if injury.status != InjuryStatusEnum.TREATED: # Can't attempt to treat a treated injury
-                    if self._proper_treatment(supply_used, injury.name, injury.location):
-                        injury.status = InjuryStatusEnum.TREATED
-                else:
-                    attempted_retreatment = True
+        doesnt_treat_injuries = [SupplyTypeEnum.BLANKET, SupplyTypeEnum.BLOOD, SupplyTypeEnum.EPI_PEN, \
+                                 SupplyTypeEnum.IV_BAG, SupplyTypeEnum.PAIN_MEDICATIONS, SupplyTypeEnum.PULSE_OXIMETER]
+        if supply_used not in doesnt_treat_injuries:
+            for injury in character.injuries:
+                if injury.location == action.parameters.get('location', None):
+                    if injury.status != InjuryStatusEnum.TREATED: # Can't attempt to treat a treated injury
+                        if self._proper_treatment(supply_used, injury.name, injury.location):
+                            injury.status = InjuryStatusEnum.TREATED
+                    else:
+                        attempted_retreatment = True
+
+        if (supply_used == SupplyTypeEnum.BLANKET):
+            if character.has_blanket:
+                attempted_retreatment = True
+            character.has_blanket = True
 
         if attempted_retreatment: # Realize the injury is already treated, but no vital/injury discovery happens
             return self.times_dict["treatmentTimes"]["ALREADY_TREATED"]

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -7,6 +7,7 @@ from swagger_server.models import (
     CharacterTag,
     InjuryLocation,
     InjuryStatusEnum,
+    InjuryTypeEnum,
     MentalStatusEnum,
     SupplyTypeEnum
 )
@@ -52,7 +53,7 @@ class ITMActionHandler:
         # This logic is in sync with the current OSU Simulator, but may diverge at a later date.
         """
             Head Injuries
-            Forehead Scrape: None
+            Forehead Scrape (Abrasion): Pressure bandage
             Face Shrapnel: Nasopharyngeal airway
             Ear Bleed: None
 
@@ -90,27 +91,30 @@ class ITMActionHandler:
             Calf Shrapnel: Pressure bandage
         """
         match injury_name:
-            case 'Amputation':
+            case InjuryTypeEnum.AMPUTATION:
                 return treatment == SupplyTypeEnum.TOURNIQUET
-            case 'Burn':
+            case InjuryTypeEnum.BURN:
                 return treatment == SupplyTypeEnum.BURN_DRESSING
-            case 'Broken Bone':
+            case InjuryTypeEnum.BROKEN_BONE:
                 return treatment == SupplyTypeEnum.SPLINT
-            case 'Chest Collapse':
+            case InjuryTypeEnum.CHEST_COLLAPSE:
                 return treatment == SupplyTypeEnum.DECOMPRESSION_NEEDLE
-            case 'Laceration':
+            case InjuryTypeEnum.ABRASION:
+                if 'face' in location:
+                    return treatment == SupplyTypeEnum.PRESSURE_BANDAGE
+            case InjuryTypeEnum.LACERATION:
                 if 'thigh' in location:
                     return treatment == SupplyTypeEnum.TOURNIQUET
                 else:
                     return treatment == SupplyTypeEnum.PRESSURE_BANDAGE
-            case 'Puncture':
+            case InjuryTypeEnum.PUNCTURE:
                 if 'bicep' in location or 'thigh' in location:
                     return treatment == SupplyTypeEnum.TOURNIQUET
                 elif 'chest' in location:
                     return treatment == SupplyTypeEnum.VENTED_CHEST_SEAL
                 else:
                     return treatment == SupplyTypeEnum.HEMOSTATIC_GAUZE
-            case 'Shrapnel':
+            case InjuryTypeEnum.SHRAPNEL:
                 if 'face' in location:
                     return treatment == SupplyTypeEnum.NASOPHARYNGEAL_AIRWAY
                 else:

--- a/swagger_server/itm/itm_scenario_reader.py
+++ b/swagger_server/itm/itm_scenario_reader.py
@@ -273,6 +273,7 @@ class ITMScenarioReader:
             id=character_data['id'],
             unstructured=character_data['unstructured'],
             unstructured_postassess=character_data.get('unstructured_postassess'),
+            has_blanket=character_data.get('has_blanket', False),
             name=character_data.get('name', 'Unknown'),
             rapport=character_data.get('rapport', 'neutral'),
             demographics=demographics,

--- a/swagger_server/models/character.py
+++ b/swagger_server/models/character.py
@@ -21,7 +21,7 @@ class Character(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, id: str=None, name: str=None, unstructured: str=None, unstructured_postassess: str=None, intent: IntentEnum=None, directness_of_causality: DirectnessEnum=None, rapport: RapportEnum=None, demographics: Demographics=None, injuries: List[Injury]=None, vitals: Vitals=None, visited: bool=False, tag: CharacterTagEnum=None):  # noqa: E501
+    def __init__(self, id: str=None, name: str=None, unstructured: str=None, unstructured_postassess: str=None, has_blanket: bool=False, intent: IntentEnum=None, directness_of_causality: DirectnessEnum=None, rapport: RapportEnum=None, demographics: Demographics=None, injuries: List[Injury]=None, vitals: Vitals=None, visited: bool=False, tag: CharacterTagEnum=None):  # noqa: E501
         """Character - a model defined in Swagger
 
         :param id: The id of this Character.  # noqa: E501
@@ -32,6 +32,8 @@ class Character(Model):
         :type unstructured: str
         :param unstructured_postassess: The unstructured_postassess of this Character.  # noqa: E501
         :type unstructured_postassess: str
+        :param has_blanket: The has_blanket of this Character.  # noqa: E501
+        :type has_blanket: bool
         :param intent: The intent of this Character.  # noqa: E501
         :type intent: IntentEnum
         :param directness_of_causality: The directness_of_causality of this Character.  # noqa: E501
@@ -54,6 +56,7 @@ class Character(Model):
             'name': str,
             'unstructured': str,
             'unstructured_postassess': str,
+            'has_blanket': bool,
             'intent': IntentEnum,
             'directness_of_causality': DirectnessEnum,
             'rapport': RapportEnum,
@@ -69,6 +72,7 @@ class Character(Model):
             'name': 'name',
             'unstructured': 'unstructured',
             'unstructured_postassess': 'unstructured_postassess',
+            'has_blanket': 'has_blanket',
             'intent': 'intent',
             'directness_of_causality': 'directness_of_causality',
             'rapport': 'rapport',
@@ -82,6 +86,7 @@ class Character(Model):
         self._name = name
         self._unstructured = unstructured
         self._unstructured_postassess = unstructured_postassess
+        self._has_blanket = has_blanket
         self._intent = intent
         self._directness_of_causality = directness_of_causality
         self._rapport = rapport
@@ -199,6 +204,29 @@ class Character(Model):
         """
 
         self._unstructured_postassess = unstructured_postassess
+
+    @property
+    def has_blanket(self) -> bool:
+        """Gets the has_blanket of this Character.
+
+        whether or not this character has a blanket (either wrapped around or underneath)  # noqa: E501
+
+        :return: The has_blanket of this Character.
+        :rtype: bool
+        """
+        return self._has_blanket
+
+    @has_blanket.setter
+    def has_blanket(self, has_blanket: bool):
+        """Sets the has_blanket of this Character.
+
+        whether or not this character has a blanket (either wrapped around or underneath)  # noqa: E501
+
+        :param has_blanket: The has_blanket of this Character.
+        :type has_blanket: bool
+        """
+
+        self._has_blanket = has_blanket
 
     @property
     def intent(self) -> IntentEnum:


### PR DESCRIPTION
Added `Character.hasBlanket` so that ADMs can tell if a blanket has been applied.  Normally treatments are conveyed via the `Injury.status` set to `treated`, but Blankets don't treat an injury (but do need to be reflected in the character).
Also added the new supplies to freeform scenarios.

Also, ninja edit to add treatment to Forehead Scape / Abrasion now that it's implemented in the sim, see ITM-406.

To test, use the Human input simulator in the [ITM-401](https://github.com/NextCenturyCorporation/itm-evaluation-client/tree/ITM-401) branch of the `itm-evaluation-client`:
- `python itm_human_input.py --session adept --scenario freeform-desert`

You don't need to run a TA1 server.
The Human input simulator is a little wonky if you've never used it before.  But basically:
1.  Type `s` then `c` to start the session and scenario.
2.  Type `v`, then `t` to take an action.  Then select one of the "treat" actions by number (e.g., `7, treat-kimberly`).
3.  Select any number for the injury location.
4.  Select the `Blanket` treatment by number.
5.  Type a justification or hit enter.
6.  Scan the displayed `State` and ensure that a `Blanket` supply was used, that Kimberly's `hasBlanket` is true (and the others' is still false), and that the elapsed time is 10.
7. Repeat steps 2-5 (trying to apply another blanket to the same patient).
8. Scan the displayed `State` and ensure that a `Blanket` supply was NOT used (it should be 998), that Kimberly's `hasBlanket` is stiill true (and the others' is still false), and that the elapsed time is 20 (10 for the blanket and 10 for a re-treatment).
9. Type `q` to quit.

[ITM-401]: https://nextcentury.atlassian.net/browse/ITM-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ