### PR TITLE
ITM-409: Remove "conscious" from Vitals

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -810,9 +810,6 @@ components:
       type: object
       description: Vital levels and other indications of health
       properties:
-        conscious:
-          type: boolean
-          description: whether or not the character appears to be conscious
         avpu:
           $ref: "#/components/schemas/AvpuLevelEnum"
         ambulatory:
@@ -1658,7 +1655,7 @@ components:
         - treated
     AvpuLevelEnum:
       type: string
-      description: Character level of response.  See [Levels of Response](https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response) for details
+      description: Character level of response; anything but ALERT is considered unconscious.  See [Levels of Response](https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response) for details
       enum:
         - ALERT
         - VOICE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-desert.yaml
@@ -87,7 +87,6 @@ state:
       injuries:
         - {name: Broken Bone, location: right shoulder, severity: major, status: visible}  # this is weird because the injuries are known at a high-level due to report, not by seeing them.  Also not filling in source_character because it is both himself and the local
       vitals:
-        conscious: true
         avpu: PAIN
         ambulatory: false
         mental_status: AGONY
@@ -110,7 +109,6 @@ state:
       injuries:
         - {name: Broken Bone, location: right shoulder, severity: major, status: visible}
       vitals:
-        conscious: true
         avpu: PAIN
         ambulatory: false
         mental_status: AGONY
@@ -197,7 +195,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: visible}  # A severe injury is "known" but you aren't present with the patients so not actually "visible"
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -219,7 +216,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: visible}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -244,7 +240,6 @@ scenes:
             mission_importance: normal
           injuries: []
           vitals:
-            conscious: true
             avpu: ALERT
             ambulatory: true
             mental_status: CALM
@@ -328,7 +323,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: visible}  # A severe injury is "known" but you aren't present with the patients so not actually "visible"
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -350,7 +344,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: visible}  # A severe injury is "known" but you aren't present with the patients so not actually "visible"
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -375,7 +368,6 @@ scenes:
             mission_importance: normal
           injuries: []
           vitals:
-            conscious: true
             avpu: ALERT
             ambulatory: true
             mental_status: CALM
@@ -453,7 +445,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -475,7 +466,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -500,7 +490,6 @@ scenes:
             mission_importance: normal
           injuries: []
           vitals:
-            conscious: true
             avpu: ALERT
             ambulatory: true
             mental_status: CALM
@@ -568,7 +557,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -592,7 +580,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -617,7 +604,6 @@ scenes:
             mission_importance: normal
           injuries: []
           vitals:
-            conscious: true
             avpu: ALERT
             ambulatory: true
             mental_status: CALM
@@ -685,7 +671,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -707,7 +692,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -732,7 +716,6 @@ scenes:
             mission_importance: normal
           injuries: []
           vitals:
-            conscious: true
             avpu: ALERT
             ambulatory: true
             mental_status: CALM
@@ -800,7 +783,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -824,7 +806,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right shoulder, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -849,7 +830,6 @@ scenes:
             mission_importance: normal
           injuries: []
           vitals:
-            conscious: true
             avpu: ALERT
             ambulatory: true
             mental_status: CALM

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
@@ -46,7 +46,6 @@ state:
         sex: M
         race: White
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false # TBD Should be true, with only shoulder injuries?
         mental_status: UPSET
@@ -77,7 +76,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -108,7 +106,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: true
         mental_status: UPSET
@@ -137,7 +134,6 @@ state:
         sex: F
         race: White
       vitals:
-        conscious: false
         avpu: PAIN
         ambulatory: false
         mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
@@ -49,7 +49,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: UPSET
@@ -83,7 +82,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -115,7 +113,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: AGONY
@@ -148,7 +145,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
@@ -45,7 +45,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -77,7 +76,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -116,7 +114,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -157,7 +154,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
@@ -53,7 +53,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: false
         avpu: PAIN
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -97,7 +96,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -128,7 +126,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -160,7 +157,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -190,7 +186,6 @@ state:
         sex: F
         race: Asian
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-jungle.yaml
@@ -81,7 +81,6 @@ state:
         - {name: Puncture, location: right shoulder, severity: substantial, status: discoverable}
         - {name: Shrapnel, location: right calf, severity: moderate, status: discoverable}
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: CONFUSED
@@ -104,7 +103,6 @@ state:
       injuries:
         - {name: Broken Bone, location: right thigh, severity: major, status: discoverable}
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: CONFUSED
@@ -173,7 +171,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: substantial, status: discoverable}
             - {name: Shrapnel, location: right calf, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED
@@ -195,7 +192,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right thigh, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED
@@ -258,7 +254,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: major, status: visible}
             - {name: Shrapnel, location: right calf, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -280,7 +275,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right thigh, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED
@@ -351,7 +345,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: substantial, status: discoverable}
             - {name: Shrapnel, location: right calf, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED
@@ -373,7 +366,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right thigh, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED
@@ -444,7 +436,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: major, status: visible}
             - {name: Shrapnel, location: right calf, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -466,7 +457,6 @@ scenes:
           injuries:
             - {name: Broken Bone, location: right thigh, severity: major, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-submarine.yaml
@@ -84,7 +84,6 @@ state:
         - {name: Internal, location: internal, severity: substantial, status: hidden}
         - {name: Ear Bleed, location: right face, severity: moderate, status: hidden}
       vitals:
-        conscious: true
         avpu: PAIN
         ambulatory: false
         mental_status: CONFUSED
@@ -109,7 +108,6 @@ state:
         - {name: Internal, location: internal, severity: substantial, status: hidden}
         - {name: Ear Bleed, location: right face, severity: moderate, status: hidden}
       vitals:
-        conscious: true
         avpu: PAIN
         ambulatory: false
         mental_status: CONFUSED
@@ -190,7 +188,6 @@ scenes:
             - {name: Internal, location: internal, severity: substantial, status: discoverable}
             - {name: Ear Bleed, location: right face, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: CONFUSED
@@ -215,7 +212,6 @@ scenes:
             - {name: Internal, location: internal, severity: substantial, status: discoverable}
             - {name: Ear Bleed, location: right face, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: CONFUSED
@@ -290,7 +286,6 @@ scenes:
             - {name: Internal, location: internal, severity: substantial, status: discoverable}
             - {name: Ear Bleed, location: right face, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED
@@ -315,7 +310,6 @@ scenes:
             - {name: Internal, location: internal, severity: substantial, status: discoverable}
             - {name: Ear Bleed, location: right face, severity: moderate, status: discoverable}
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: CONFUSED
@@ -337,7 +331,6 @@ scenes:
           injuries:
             - {name: Internal, location: internal, severity: major, status: visible}  # Known but not actually visible because they are in another part of the submarine
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-urban.yaml
@@ -88,7 +88,6 @@ state:
         - {name: Puncture, location: right shoulder, severity: extreme, status: visible, source_character: patient_2_victim}
         - {name: Puncture, location: right bicep, severity: moderate, status: visible, source_character: patient_2_victim}
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -114,7 +113,6 @@ state:
         - {name: Puncture, location: right bicep, severity: moderate, status: visible, source_character: patient_1_shooter}
         - {name: Puncture, location: right chest, severity: moderate, status: visible, source_character: patient_1_shooter}
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -188,7 +186,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: extreme, status: visible}
             - {name: Puncture, location: right bicep, severity: moderate, status: visible}
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -209,7 +206,6 @@ scenes:
             - {name: Puncture, location: right bicep, severity: moderate, status: visible, source_character: patient_1_shooter}
             - {name: Puncture, location: right chest, severity: moderate, status: visible, source_character: patient_1_shooter}
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -281,7 +277,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: extreme, status: visible}
             - {name: Puncture, location: right bicep, severity: moderate, status: visible}
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -302,7 +297,6 @@ scenes:
             - {name: Puncture, location: right bicep, severity: moderate, status: visible, source_character: patient_1_shooter}
             - {name: Puncture, location: right chest, severity: moderate, status: visible, source_character: patient_1_shooter}
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -372,7 +366,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: extreme, status: visible}  # should be marked as treated, but validator doesn't except that
             - {name: Puncture, location: right bicep, severity: moderate, status: visible}  # should be marked as treated, but validator doesn't except that
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -393,7 +386,6 @@ scenes:
             - {name: Puncture, location: right bicep, severity: moderate, status: visible, source_character: patient_1_shooter}  # should be marked as treated, but validator doesn't except that
             - {name: Puncture, location: right chest, severity: moderate, status: visible, source_character: patient_1_shooter}  # should be marked as treated, but validator doesn't except that
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -461,7 +453,6 @@ scenes:
             - {name: Puncture, location: right shoulder, severity: extreme, status: visible}  # should be marked as treated, but validator doesn't except that
             - {name: Puncture, location: right bicep, severity: moderate, status: visible}  # should be marked as treated, but validator doesn't except that
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -482,7 +473,6 @@ scenes:
             - {name: Puncture, location: right bicep, severity: major, status: visible, source_character: patient_1_shooter}  # increased severity from previous scenes
             - {name: Puncture, location: right chest, severity: moderate, status: visible, source_character: patient_1_shooter}
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-desert.yaml
@@ -44,7 +44,6 @@ state:
         sex: M
         race: White
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -66,7 +65,6 @@ state:
         sex: M
         race: White
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -141,7 +139,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -165,7 +162,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -235,7 +231,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -259,7 +254,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -332,7 +326,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -354,7 +347,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -429,7 +421,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -455,7 +446,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -529,7 +519,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -557,7 +546,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -630,7 +618,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -658,7 +645,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -735,7 +721,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -761,7 +746,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -839,7 +823,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -866,7 +849,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -941,7 +923,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -970,7 +951,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1044,7 +1024,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1073,7 +1052,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1151,7 +1129,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1178,7 +1155,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -1256,7 +1232,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1283,7 +1258,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1358,7 +1332,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1387,7 +1360,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1461,7 +1433,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1490,7 +1461,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1568,7 +1538,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1595,7 +1564,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -1673,7 +1641,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1700,7 +1667,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1775,7 +1741,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1804,7 +1769,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1878,7 +1842,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1907,7 +1870,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1985,7 +1947,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -2012,7 +1973,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -2087,7 +2047,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -2110,7 +2069,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -2133,7 +2091,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -2214,7 +2171,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -2241,7 +2197,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -2268,7 +2223,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-jungle.yaml
@@ -49,7 +49,6 @@ state:
         military_disposition: Allied US
         military_branch: US Army
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: CONFUSED
@@ -76,7 +75,6 @@ state:
         military_disposition: Allied US
         military_branch: US Army
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: CONFUSED
@@ -103,7 +101,6 @@ state:
         military_disposition: Allied US
         military_branch: US Army
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: true
         mental_status: AGONY

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-submarine.yaml
@@ -47,7 +47,6 @@ state:
         military_disposition: Allied US
         military_branch: US Army
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -70,7 +69,6 @@ state:
         race: White
         military_disposition: Civilian
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -184,7 +182,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -211,7 +208,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -284,7 +280,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -310,7 +305,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -383,7 +377,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -410,7 +403,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -483,7 +475,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -509,7 +500,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -582,7 +572,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -609,7 +598,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -682,7 +670,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -708,7 +695,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -781,7 +767,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -808,7 +793,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -881,7 +865,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -907,7 +890,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-training-urban.yaml
@@ -47,7 +47,6 @@ state:
         sex: M
         race: White
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: SHOCK
@@ -69,7 +68,6 @@ state:
         sex: M
         race: White
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: SHOCK
@@ -143,7 +141,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -166,7 +163,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -236,7 +232,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -260,7 +255,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -329,7 +323,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -351,7 +344,6 @@ scenes:
             sex: M
             race: White
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -425,7 +417,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -451,7 +442,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -523,7 +513,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -550,7 +539,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -622,7 +610,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -650,7 +637,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -721,7 +707,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -747,7 +732,6 @@ scenes:
             race: White
             military_disposition: Civilian
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -825,7 +809,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -852,7 +835,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -926,7 +908,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -954,7 +935,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1028,7 +1008,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1057,7 +1036,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1130,7 +1108,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1157,7 +1134,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -1235,7 +1211,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1262,7 +1237,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1336,7 +1310,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1364,7 +1337,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1438,7 +1410,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1467,7 +1438,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1540,7 +1510,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1567,7 +1536,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY
@@ -1645,7 +1613,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1671,7 +1638,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1745,7 +1711,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1772,7 +1737,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: VOICE
             ambulatory: false
             mental_status: SHOCK
@@ -1846,7 +1810,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: SHOCK
@@ -1874,7 +1837,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1947,7 +1909,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: false
             avpu: UNRESPONSIVE
             ambulatory: false
             mental_status: UNRESPONSIVE
@@ -1973,7 +1934,6 @@ scenes:
             military_disposition: Allied US
             military_branch: US Army
           vitals:
-            conscious: true
             avpu: PAIN
             ambulatory: false
             mental_status: AGONY

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-desert.yaml
@@ -236,7 +236,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -260,7 +260,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -429,7 +429,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 93
     environment:
@@ -571,7 +570,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 70
     - demographics:
@@ -600,7 +598,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 69
     environment:
@@ -785,7 +782,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 92
     - demographics:
@@ -814,7 +810,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     environment:
@@ -981,7 +976,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 92
     - demographics:
@@ -1010,7 +1004,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 91
     environment:
@@ -1160,7 +1153,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 92
     - demographics:
@@ -1189,7 +1181,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 91
     environment:
@@ -1341,7 +1332,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1370,7 +1361,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1520,7 +1511,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1549,7 +1540,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1715,7 +1706,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     environment:
@@ -1900,7 +1890,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1934,7 +1923,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2100,7 +2088,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -2134,7 +2121,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2284,7 +2270,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -2318,7 +2303,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2410,7 +2394,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2434,7 +2418,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2452,7 +2436,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2470,7 +2454,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
@@ -46,7 +46,6 @@ state:
         sex: M
         race: White
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false # TBD Should be true, with only shoulder injuries?
         mental_status: UPSET
@@ -77,7 +76,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -108,7 +106,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: true
         mental_status: UPSET
@@ -137,7 +134,6 @@ state:
         sex: F
         race: White
       vitals:
-        conscious: false
         avpu: PAIN
         ambulatory: false
         mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
@@ -49,7 +49,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: UPSET
@@ -83,7 +82,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -115,7 +113,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: VOICE
         ambulatory: false
         mental_status: AGONY
@@ -148,7 +145,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
@@ -45,7 +45,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -77,7 +76,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -116,7 +114,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -157,7 +154,6 @@ state:
         military_disposition: Allied US
         military_branch: US Navy
       vitals:
-        conscious: false
         avpu: UNRESPONSIVE
         ambulatory: false
         mental_status: UNRESPONSIVE

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
@@ -53,7 +53,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: false
         avpu: PAIN
         ambulatory: false
         mental_status: UNRESPONSIVE
@@ -97,7 +96,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -128,7 +126,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -160,7 +157,6 @@ state:
         military_disposition: Allied US
         military_branch: US Marine Corps
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY
@@ -190,7 +186,6 @@ state:
         sex: F
         race: Asian
       vitals:
-        conscious: true
         avpu: ALERT
         ambulatory: false
         mental_status: AGONY

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-jungle.yaml
@@ -148,7 +148,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -173,7 +173,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -314,7 +314,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 95
     - demographics:
@@ -341,7 +340,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -475,7 +474,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 70
     - demographics:
@@ -505,7 +503,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 70
     environment:
@@ -647,7 +644,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: RESTRICTED
-        conscious: true
         heart_rate: FAST
         spo2: 70
     - demographics:
@@ -677,7 +673,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 70
     environment:
@@ -834,7 +829,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 95
     - demographics:
@@ -864,7 +858,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 95
     environment:
@@ -1014,7 +1007,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 95
     - demographics:
@@ -1044,7 +1036,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 95
     environment:
@@ -1197,7 +1188,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1226,7 +1217,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1376,7 +1367,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1405,7 +1396,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1571,7 +1562,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1605,7 +1595,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 98
     environment:
@@ -1779,7 +1768,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1813,7 +1801,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -1976,7 +1963,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -2010,7 +1996,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2160,7 +2145,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -2194,7 +2178,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2286,7 +2269,7 @@ state:
 
       '
     vitals:
-      conscious: true
+        avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2311,7 +2294,7 @@ state:
 
       '
     vitals:
-      conscious: true
+        avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2329,7 +2312,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+        avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2347,7 +2330,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+        avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-submarine.yaml
@@ -145,7 +145,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -170,7 +170,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -305,7 +305,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     - demographics:
@@ -332,7 +331,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -460,7 +459,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: NORMAL
         spo2: 95
     - demographics:
@@ -490,7 +488,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 70
     environment:
@@ -637,7 +634,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: NORMAL
         spo2: 95
     - demographics:
@@ -667,7 +663,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 70
     environment:
@@ -820,7 +815,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     - demographics:
@@ -850,7 +844,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     environment:
@@ -995,7 +988,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     - demographics:
@@ -1025,7 +1017,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     environment:
@@ -1172,7 +1163,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1201,7 +1192,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1345,7 +1336,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1374,7 +1365,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1534,7 +1525,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1568,7 +1558,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 98
     environment:
@@ -1758,7 +1747,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1792,7 +1780,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -1951,7 +1938,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1985,7 +1971,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2129,7 +2114,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -2163,7 +2147,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2249,7 +2232,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2274,7 +2257,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2292,7 +2275,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2310,7 +2293,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-urban.yaml
@@ -236,7 +236,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -260,7 +260,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -428,7 +428,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 93
     - demographics:
@@ -457,7 +456,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 95
     environment:
@@ -598,7 +596,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 71
     - demographics:
@@ -627,7 +624,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 69
     environment:
@@ -811,7 +807,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 92
     - demographics:
@@ -840,7 +835,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     environment:
@@ -1006,7 +1000,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 92
     - demographics:
@@ -1035,7 +1028,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 91
     environment:
@@ -1184,7 +1176,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 92
     - demographics:
@@ -1213,7 +1204,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 91
     environment:
@@ -1365,7 +1355,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1394,7 +1384,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1543,7 +1533,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1572,7 +1562,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1737,7 +1727,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1771,7 +1760,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 98
     environment:
@@ -1955,7 +1943,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -1989,7 +1976,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2154,7 +2140,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -2188,7 +2173,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2337,7 +2321,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 90
     - demographics:
@@ -2371,7 +2354,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2462,7 +2444,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2486,7 +2468,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2504,7 +2486,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2522,7 +2504,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-desert.yaml
@@ -236,7 +236,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -260,7 +260,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -429,7 +429,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 96
     environment:
@@ -571,7 +570,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 72
     - demographics:
@@ -600,7 +598,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 72
     environment:
@@ -785,7 +782,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -814,7 +810,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     environment:
@@ -981,7 +976,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1010,7 +1004,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 93
     environment:
@@ -1160,7 +1153,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1189,7 +1181,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 93
     environment:
@@ -1341,7 +1332,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1370,7 +1361,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1520,7 +1511,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1549,7 +1540,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1715,7 +1706,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     environment:
@@ -1900,7 +1890,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1934,7 +1923,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2100,7 +2088,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -2134,7 +2121,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2284,7 +2270,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -2318,7 +2303,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2410,7 +2394,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2434,7 +2418,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2452,7 +2436,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2470,7 +2454,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-jungle.yaml
@@ -148,7 +148,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -173,7 +173,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -314,7 +314,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 96
     - demographics:
@@ -341,7 +340,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -475,7 +474,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 75
     - demographics:
@@ -505,7 +503,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 72
     environment:
@@ -647,7 +644,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 75
     - demographics:
@@ -677,7 +673,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 72
     environment:
@@ -834,7 +829,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 93
     - demographics:
@@ -864,7 +858,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 93
     environment:
@@ -1014,7 +1007,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 93
     - demographics:
@@ -1044,7 +1036,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: NORMAL
         spo2: 93
     environment:
@@ -1197,7 +1188,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1226,7 +1217,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1376,7 +1367,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1405,7 +1396,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1571,7 +1562,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1605,7 +1595,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 97
     environment:
@@ -1779,7 +1768,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1813,7 +1801,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -1976,7 +1963,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -2010,7 +1996,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2160,7 +2145,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -2194,7 +2178,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2286,7 +2269,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2311,7 +2294,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2329,7 +2312,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2347,7 +2330,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-submarine.yaml
@@ -145,7 +145,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -170,7 +170,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -305,7 +305,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 75
     - demographics:
@@ -332,7 +331,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -460,7 +459,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: NORMAL
         spo2: 97
     - demographics:
@@ -490,7 +488,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 72
     environment:
@@ -637,7 +634,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: NORMAL
         spo2: 97
     - demographics:
@@ -667,7 +663,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 72
     environment:
@@ -820,7 +815,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 72
     - demographics:
@@ -850,7 +844,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 69
     environment:
@@ -995,7 +988,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 72
     - demographics:
@@ -1025,7 +1017,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 69
     environment:
@@ -1172,7 +1163,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1201,7 +1192,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1345,7 +1336,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1374,7 +1365,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1534,7 +1525,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1568,7 +1558,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 97
     environment:
@@ -1758,7 +1747,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1792,7 +1780,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 97
     environment:
@@ -1951,7 +1938,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1985,7 +1971,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 97
     environment:
@@ -2129,7 +2114,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -2163,7 +2147,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 97
     environment:
@@ -2249,7 +2232,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2274,7 +2257,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2292,7 +2275,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2310,7 +2293,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-training-urban.yaml
@@ -236,7 +236,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 36
         military_branch: US Marine Corps
@@ -260,7 +260,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -428,7 +428,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 96
     - demographics:
@@ -457,7 +456,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 94
     environment:
@@ -598,7 +596,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 70
     - demographics:
@@ -627,7 +624,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NONE
-        conscious: false
         heart_rate: FAST
         spo2: 72
     environment:
@@ -811,7 +807,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -840,7 +835,6 @@ scenes:
       vitals:
         avpu: PAIN
         breathing: NONE
-        conscious: true
         heart_rate: FAST
         spo2: 70
     environment:
@@ -1006,7 +1000,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1035,7 +1028,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 93
     environment:
@@ -1184,7 +1176,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1213,7 +1204,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 93
     environment:
@@ -1365,7 +1355,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1394,7 +1384,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1543,7 +1533,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     - demographics:
         age: 25
         military_branch: US Marine Corps
@@ -1572,7 +1562,7 @@ scenes:
 
         '
       vitals:
-        conscious: true
+        avpu: ALERT
     environment:
       decision_environment:
         aid_delay:
@@ -1737,7 +1727,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1771,7 +1760,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: NORMAL
-        conscious: true
         heart_rate: FAST
         spo2: 97
     environment:
@@ -1955,7 +1943,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -1989,7 +1976,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2154,7 +2140,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -2188,7 +2173,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2337,7 +2321,6 @@ scenes:
       vitals:
         avpu: ALERT
         breathing: FAST
-        conscious: true
         heart_rate: FAST
         spo2: 91
     - demographics:
@@ -2371,7 +2354,6 @@ scenes:
       vitals:
         avpu: UNRESPONSIVE
         breathing: NORMAL
-        conscious: false
         heart_rate: FAST
         spo2: 98
     environment:
@@ -2462,7 +2444,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 36
       military_branch: US Marine Corps
@@ -2486,7 +2468,7 @@ state:
 
       '
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 29
       military_branch: US Marine Corps
@@ -2504,7 +2486,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   - demographics:
       age: 25
       military_branch: US Marine Corps
@@ -2522,7 +2504,7 @@ state:
     rapport: neutral
     unstructured: ''
     vitals:
-      conscious: true
+      avpu: ALERT
   environment:
     decision_environment:
       aid_delay:

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -212,7 +212,6 @@ class ITMActionHandler:
         patient.vitals.ambulatory = patient_template.vitals.ambulatory
         patient.vitals.avpu = patient_template.vitals.avpu
         patient.vitals.breathing = patient_template.vitals.breathing
-        patient.vitals.conscious = patient_template.vitals.conscious
         patient.vitals.mental_status = patient_template.vitals.mental_status
         self._reveal_injuries(patient_template, patient)
         patient.visited = True
@@ -323,11 +322,10 @@ class ITMActionHandler:
         for character in self.session.state.characters:
             for isd_character in self.current_scene.state.characters:
                 if isd_character.id == character.id:
-                    if isd_character.vitals.ambulatory and isd_character.vitals.conscious and \
+                    if isd_character.vitals.ambulatory and \
                     isd_character.vitals.avpu == AvpuLevelEnum.ALERT and \
                     isd_character.vitals.mental_status in [MentalStatusEnum.CALM, MentalStatusEnum.UPSET]:
                         character.vitals.ambulatory = True
-                        character.vitals.conscious = True
                         character.vitals.avpu = AvpuLevelEnum.ALERT
                         character.vitals.mental_status = isd_character.vitals.mental_status
         return self.times_dict["DIRECT_MOBILE_CHARACTERS"]

--- a/swagger_server/itm/itm_scenario_reader.py
+++ b/swagger_server/itm/itm_scenario_reader.py
@@ -289,7 +289,6 @@ class ITMScenarioReader:
         if not vital_data:
             return None
         vitals = Vitals(
-            conscious=vital_data.get('conscious'),
             avpu=vital_data.get('avpu'),
             ambulatory=vital_data.get('ambulatory'),
             mental_status=vital_data.get('mental_status'),

--- a/swagger_server/itm/itm_scene.py
+++ b/swagger_server/itm/itm_scene.py
@@ -41,6 +41,8 @@ class ITMScene:
         else:
             self.default_next_scene = scene.next_scene
         for mapping in self.action_mappings:
+            if mapping.action_type == 'END_SCENE':
+                self.end_scene_allowed = True
             if mapping.next_scene is None or mapping.next_scene == '':
                 mapping.next_scene = self.default_next_scene # if not specified in action mapping, inherit from scene
             logging.debug('mapping id %s has next scene of %s.', mapping.action_id, mapping.next_scene)

--- a/swagger_server/models/vitals.py
+++ b/swagger_server/models/vitals.py
@@ -18,11 +18,9 @@ class Vitals(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, conscious: bool=None, avpu: AvpuLevelEnum=None, ambulatory: bool=None, mental_status: MentalStatusEnum=None, breathing: BreathingLevelEnum=None, heart_rate: HeartRateEnum=None, spo2: float=None):  # noqa: E501
+    def __init__(self, avpu: AvpuLevelEnum=None, ambulatory: bool=None, mental_status: MentalStatusEnum=None, breathing: BreathingLevelEnum=None, heart_rate: HeartRateEnum=None, spo2: float=None):  # noqa: E501
         """Vitals - a model defined in Swagger
 
-        :param conscious: The conscious of this Vitals.  # noqa: E501
-        :type conscious: bool
         :param avpu: The avpu of this Vitals.  # noqa: E501
         :type avpu: AvpuLevelEnum
         :param ambulatory: The ambulatory of this Vitals.  # noqa: E501
@@ -37,7 +35,6 @@ class Vitals(Model):
         :type spo2: float
         """
         self.swagger_types = {
-            'conscious': bool,
             'avpu': AvpuLevelEnum,
             'ambulatory': bool,
             'mental_status': MentalStatusEnum,
@@ -47,7 +44,6 @@ class Vitals(Model):
         }
 
         self.attribute_map = {
-            'conscious': 'conscious',
             'avpu': 'avpu',
             'ambulatory': 'ambulatory',
             'mental_status': 'mental_status',
@@ -55,7 +51,6 @@ class Vitals(Model):
             'heart_rate': 'heart_rate',
             'spo2': 'spo2'
         }
-        self._conscious = conscious
         self._avpu = avpu
         self._ambulatory = ambulatory
         self._mental_status = mental_status
@@ -73,29 +68,6 @@ class Vitals(Model):
         :rtype: Vitals
         """
         return util.deserialize_model(dikt, cls)
-
-    @property
-    def conscious(self) -> bool:
-        """Gets the conscious of this Vitals.
-
-        whether or not the character appears to be conscious  # noqa: E501
-
-        :return: The conscious of this Vitals.
-        :rtype: bool
-        """
-        return self._conscious
-
-    @conscious.setter
-    def conscious(self, conscious: bool):
-        """Sets the conscious of this Vitals.
-
-        whether or not the character appears to be conscious  # noqa: E501
-
-        :param conscious: The conscious of this Vitals.
-        :type conscious: bool
-        """
-
-        self._conscious = conscious
 
     @property
     def avpu(self) -> AvpuLevelEnum:


### PR DESCRIPTION
* Remove `conscious` vital and update scenarios accordingly;
* Fix bug ending scene action mappings.

Use with the client [ITM-409](https://github.com/NextCenturyCorporation/itm-evaluation-client/tree/ITM-409) branch and corresponding [PR](https://github.com/NextCenturyCorporation/itm-evaluation-client/pull/32).

One way to test is with something like
- `python itm_minimal_runner.py --session adept --name foobar --count 200`

This will run 200 copies of ADEPT evaluation scenarios (and freeform scenarios) without the TA1 server.
Then switch `adept` to `soartech` and then repeat both with `--training`.

And try anything else you wish, such as an `eval` session.

[ITM-409]: https://nextcentury.atlassian.net/browse/ITM-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ