### PR TITLE
ITM-420:  Added fentanyl lollipop

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1414,6 +1414,7 @@ components:
         - Epi Pen
         - Vented Chest Seal
         - Pain Medications
+        - Fentanyl Lollipop
         - Splint
         - Blood
         - IV Bag

--- a/swagger_server/itm/data/actionTimes.json
+++ b/swagger_server/itm/data/actionTimes.json
@@ -10,6 +10,7 @@
         "Epi Pen": 10,
         "Vented Chest Seal": 100,
         "Pain Medications": 10,
+        "Fentanyl Lollipop": 10,
         "Splint": 80,
         "Blood": 30,
         "IV Bag": 30,

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-desert.yaml
@@ -28,6 +28,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-jungle.yaml
@@ -29,6 +29,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-submarine.yaml
@@ -25,6 +25,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-adept-eval-freeform-urban.yaml
@@ -34,6 +34,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-desert.yaml
@@ -28,6 +28,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-jungle.yaml
@@ -29,6 +29,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-submarine.yaml
@@ -25,6 +25,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
+++ b/swagger_server/itm/data/metrics/scenarios/metrics-soartech-eval-freeform-urban.yaml
@@ -34,6 +34,7 @@ state:
     - { type: Nasopharyngeal airway, quantity: 999 }
     - { type: Pulse Oximeter, quantity: 1, reusable: True }
     - { type: Pain Medications, quantity: 999 }
+    - { type: Fentanyl Lollipop, quantity: 999 }
     - { type: Splint, quantity: 999 }
     - { type: Blood, quantity: 999 }
     - { type: Burn Dressing, quantity: 999 }

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -233,7 +233,7 @@ class ITMActionHandler:
         # If the treatment treats the injury at the specified location, then change its status to treated.
         supply_used = action.parameters.get('treatment', None)
         attempted_retreatment = False
-        doesnt_treat_injuries = [SupplyTypeEnum.BLANKET, SupplyTypeEnum.BLOOD, SupplyTypeEnum.EPI_PEN, \
+        doesnt_treat_injuries = [SupplyTypeEnum.BLANKET, SupplyTypeEnum.BLOOD, SupplyTypeEnum.EPI_PEN, SupplyTypeEnum.FENTANYL_LOLLIPOP, \
                                  SupplyTypeEnum.IV_BAG, SupplyTypeEnum.PAIN_MEDICATIONS, SupplyTypeEnum.PULSE_OXIMETER]
         if supply_used not in doesnt_treat_injuries:
             for injury in character.injuries:

--- a/swagger_server/models/supply_type_enum.py
+++ b/swagger_server/models/supply_type_enum.py
@@ -28,6 +28,7 @@ class SupplyTypeEnum(Model):
     EPI_PEN = "Epi Pen"
     VENTED_CHEST_SEAL = "Vented Chest Seal"
     PAIN_MEDICATIONS = "Pain Medications"
+    FENTANYL_LOLLIPOP = "Fentanyl Lollipop"
     SPLINT = "Splint"
     BLOOD = "Blood"
     IV_BAG = "IV Bag"


### PR DESCRIPTION
Use the [ITM-420 client branch](https://github.com/NextCenturyCorporation/itm-evaluation-client/tree/ITM-420) and run soartech and adept session types.  You can also use the human ADM simulator to make sure you can choose the fentanyl lollipop treatment (location is ignored).

[Here's](https://github.com/NextCenturyCorporation/itm-evaluation-client/pull/34) the corresponding client PR.