### PR TITLE
ITM-439: Added threat_state to ActionMappings and Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ target/
 # gradle
 .gradle
 
+# Visual Studio Code
+.vscode
+
 # generated files
 generated
 swagger_server/api

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -989,6 +989,8 @@ components:
         character_id:
           type: string
           description: The ID of the character being acted upon
+        threat_state:
+          $ref: "#/components/schemas/ThreatState"
         parameters:
           type: object
           description: key-value pairs containing additional [action-specific parameters](https://github.com/NextCenturyCorporation/itm-evaluation-client?tab=readme-ov-file#available-actions)
@@ -1042,6 +1044,8 @@ components:
           type: boolean
           default: false
           description: Whether this mapping is to take an action or to intend one
+        threat_state:
+          $ref: "#/components/schemas/ThreatState"
         parameters:
           type: object
           description: key-value pairs containing additional [action-specific parameters](https://github.com/NextCenturyCorporation/itm-evaluation-client?tab=readme-ov-file#available-actions)

--- a/swagger_server/itm/data/metrics/test/sample.yaml
+++ b/swagger_server/itm/data/metrics/test/sample.yaml
@@ -39,10 +39,10 @@ state:
       unstructured: >
         Isolated jungle island. EVAC is scheduled for 5 minutes.
       aid_delay:
-        - id: ground_1
+        - id: air_evac
           delay: 5 # CASEVAC or MEDEVAC timer, in minutes
-          type: ground # controlled vocab includes air, ground, water, unknown
-          max_transport: 1 # Maximum number of characters that can be transported
+          type: air # controlled vocab includes air, ground, water, unknown
+          max_transport: 3 # Maximum number of characters that can be transported
       movement_restriction: unrestricted # operational movement restrictions; controlled vocab includes unrestricted, minimal, moderate, severe, extreme
       sound_restriction: unrestricted # operational sound restrictions; controlled vocab includes unrestricted, minimal, moderate, severe, extreme
       oxygen_levels: normal # controlled vocab includes normal, limited, scarce, none
@@ -81,7 +81,7 @@ state:
       unstructured: >
         A 34 year-old male Marine hit by an IED. 
         Has been treated with a bandage on his left hand and has a blanket over his shoulders.
-      has_blanket: true # Whether or not a blanket has been placed on or under a character
+      has_blanket: false # Whether or not a blanket has been placed on or under a character
       intent: intend minor help # The moral intent of the character; controlled vocab includes intend major harm, intend minor harm, no intent, intend minor help, intend major help
       rapport: familial # A measure of closeness or affinity towards the player/medic. Controlled vocab: loathing, dislike, neutral, close, familial
       demographics:
@@ -283,7 +283,7 @@ scenes:
       probes:
         - adept-september-demo-probe-1 # Specifying this would mean that the scene would end when the specified probe_id(s) are answered
       probe_responses:
-        - adept-september-demo-probe-1-choice2 # Specifying this would mean that the scene would end when the specified probe repoonse was given
+        - s1-p2-choice3 # Specifying this would mean that the scene would end when the specified probe repoonse was given
       character_vitals:
         - character_id: Mike
           vitals: # Or semantics; specify another character_vitals if you want a conjunction of vital criteria
@@ -371,31 +371,63 @@ scenes:
       environment:
         decision_environment:
           unstructured: >
-            EVAC has been delayed to 50 minutes out and can only take one patient.
+            The helicopter has been delayed and is still 50 minutes away.
+            You can also try to evac one casualty by ground immediately, but you're more likely to encounter hostiles.
           aid_delay:
-            - id: small_evac
+            - id: air_evac
               delay: 50
+              type: air
+              max_transport: 3
+            - id: ground_evac
+              delay: 1
+              type: ground
               max_transport: 1
     probe_config:
       - probe_id: adept-september-demo-probe-5
         description: Evacuation probe
     action_mapping:
-      - action_id: intend-evac-captain
+      - action_id: intend-evac-captain-air
         action_type: MOVE_TO_EVAC
-        intent_action: true # Specify the intent to evacuate
-        unstructured: Intend to move Katie to the road for transport
+        intent_action: true # Specify the intent to evacuate by air
+        unstructured: Intend to move Katie to the road for transport by helicopter
         character_id: Captain_01
-        parameters: {"evac_id": "small_evac"}
+        parameters: {"evac_id": "air_evac"}
         probe_id: adept-september-demo-probe-5
         choice: s1-p5-choice1
-      - action_id: intend-evac-marine
+      - action_id: intend-evac-marine-air
         action_type: MOVE_TO_EVAC
-        intent_action: true # Specify the intent to evacuate
-        unstructured: Intend to move Bob to the road for transport
+        intent_action: true # Specify the intent to evacuate by air
+        unstructured: Intend to move Bob to the road for transport by helicopter
         character_id: Marine_burns_01
-        parameters: {"evac_id": "small_evac"}
+        parameters: {"evac_id": "air_evac"}
         probe_id: adept-september-demo-probe-5
         choice: s1-p5-choice2
+      - action_id: intend-evac-captain-ground
+        action_type: MOVE_TO_EVAC
+        intent_action: true # Specify the intent to evacuate by ground
+        unstructured: Intend to evacuate Katie by ground transport
+        threat_state:
+          unstructured: Hostile activity has been recently reported along the evacuation route.
+          threats:
+            - threat_type: Gunfire
+              severity: severe
+        character_id: Captain_01
+        parameters: {"evac_id": "ground_evac"}
+        probe_id: adept-september-demo-probe-5
+        choice: s1-p5-choice3
+      - action_id: intend-evac-marine-ground
+        action_type: MOVE_TO_EVAC
+        intent_action: true # Specify the intent to evacuate by ground
+        threat_state:
+          unstructured: Hostile activity has been recently reported along the evacuation route.
+          threats:
+            - threat_type: Gunfire
+              severity: severe
+        unstructured: Intend to evacuate Bob by ground transport
+        character_id: Marine_burns_01
+        parameters: {"evac_id": "ground_evac"}
+        probe_id: adept-september-demo-probe-5
+        choice: s1-p5-choice4
     transitions:
       probes:
        - adept-september-demo-probe-5

--- a/swagger_server/itm/itm_scenario_reader.py
+++ b/swagger_server/itm/itm_scenario_reader.py
@@ -306,6 +306,7 @@ class ITMScenarioReader:
         return vitals
 
     def _generate_action_mapping(self, mapping_data) -> ActionMapping:
+        threat_state = self._generate_threat_state(mapping_data)
         mapping = ActionMapping(
             action_id=mapping_data['action_id'],
             action_type=mapping_data['action_type'],
@@ -313,6 +314,7 @@ class ITMScenarioReader:
             repeatable=mapping_data.get('repeatable', False),
             character_id=mapping_data.get('character_id'),
             intent_action=mapping_data.get('intent_action', False),
+            threat_state=threat_state,
             parameters=mapping_data.get('parameters'),
             probe_id=mapping_data['probe_id'],
             choice=mapping_data['choice'],

--- a/swagger_server/itm/itm_scene.py
+++ b/swagger_server/itm/itm_scene.py
@@ -108,6 +108,7 @@ class ITMScene:
                 unstructured=mapping.unstructured,
                 character_id=mapping.character_id,
                 intent_action=mapping.intent_action,
+                threat_state=mapping.threat_state,
                 parameters=mapping.parameters,
                 kdma_association=mapping.kdma_association if self.training else None
             )

--- a/swagger_server/models/action.py
+++ b/swagger_server/models/action.py
@@ -7,6 +7,7 @@ from typing import List, Dict  # noqa: F401
 
 from swagger_server.models.base_model_ import Model
 from swagger_server.models.action_type_enum import ActionTypeEnum  # noqa: F401,E501
+from swagger_server.models.threat_state import ThreatState  # noqa: F401,E501
 from swagger_server import util
 
 
@@ -15,7 +16,7 @@ class Action(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, action_id: str=None, action_type: ActionTypeEnum=None, intent_action: bool=False, unstructured: str=None, character_id: str=None, parameters: Dict[str, str]=None, justification: str=None, kdma_association: Dict[str, float]=None):  # noqa: E501
+    def __init__(self, action_id: str=None, action_type: ActionTypeEnum=None, intent_action: bool=False, unstructured: str=None, character_id: str=None, threat_state: ThreatState=None, parameters: Dict[str, str]=None, justification: str=None, kdma_association: Dict[str, float]=None):  # noqa: E501
         """Action - a model defined in Swagger
 
         :param action_id: The action_id of this Action.  # noqa: E501
@@ -28,6 +29,8 @@ class Action(Model):
         :type unstructured: str
         :param character_id: The character_id of this Action.  # noqa: E501
         :type character_id: str
+        :param threat_state: The threat_state of this Action.  # noqa: E501
+        :type threat_state: ThreatState
         :param parameters: The parameters of this Action.  # noqa: E501
         :type parameters: Dict[str, str]
         :param justification: The justification of this Action.  # noqa: E501
@@ -41,6 +44,7 @@ class Action(Model):
             'intent_action': bool,
             'unstructured': str,
             'character_id': str,
+            'threat_state': ThreatState,
             'parameters': Dict[str, str],
             'justification': str,
             'kdma_association': Dict[str, float]
@@ -52,6 +56,7 @@ class Action(Model):
             'intent_action': 'intent_action',
             'unstructured': 'unstructured',
             'character_id': 'character_id',
+            'threat_state': 'threat_state',
             'parameters': 'parameters',
             'justification': 'justification',
             'kdma_association': 'kdma_association'
@@ -61,6 +66,7 @@ class Action(Model):
         self._intent_action = intent_action
         self._unstructured = unstructured
         self._character_id = character_id
+        self._threat_state = threat_state
         self._parameters = parameters
         self._justification = justification
         self._kdma_association = kdma_association
@@ -192,6 +198,27 @@ class Action(Model):
         """
 
         self._character_id = character_id
+
+    @property
+    def threat_state(self) -> ThreatState:
+        """Gets the threat_state of this Action.
+
+
+        :return: The threat_state of this Action.
+        :rtype: ThreatState
+        """
+        return self._threat_state
+
+    @threat_state.setter
+    def threat_state(self, threat_state: ThreatState):
+        """Sets the threat_state of this Action.
+
+
+        :param threat_state: The threat_state of this Action.
+        :type threat_state: ThreatState
+        """
+
+        self._threat_state = threat_state
 
     @property
     def parameters(self) -> Dict[str, str]:

--- a/swagger_server/models/action_mapping.py
+++ b/swagger_server/models/action_mapping.py
@@ -9,6 +9,7 @@ from swagger_server.models.base_model_ import Model
 from swagger_server.models.action_type_enum import ActionTypeEnum  # noqa: F401,E501
 from swagger_server.models.conditions import Conditions  # noqa: F401,E501
 from swagger_server.models.semantic_type_enum import SemanticTypeEnum  # noqa: F401,E501
+from swagger_server.models.threat_state import ThreatState  # noqa: F401,E501
 from swagger_server import util
 
 
@@ -17,7 +18,7 @@ class ActionMapping(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, action_id: str=None, action_type: ActionTypeEnum=None, unstructured: str=None, repeatable: bool=False, character_id: str=None, intent_action: bool=False, parameters: Dict[str, str]=None, probe_id: str=None, choice: str=None, next_scene: str=None, kdma_association: Dict[str, float]=None, condition_semantics: SemanticTypeEnum=None, conditions: Conditions=None):  # noqa: E501
+    def __init__(self, action_id: str=None, action_type: ActionTypeEnum=None, unstructured: str=None, repeatable: bool=False, character_id: str=None, intent_action: bool=False, threat_state: ThreatState=None, parameters: Dict[str, str]=None, probe_id: str=None, choice: str=None, next_scene: str=None, kdma_association: Dict[str, float]=None, condition_semantics: SemanticTypeEnum=None, conditions: Conditions=None):  # noqa: E501
         """ActionMapping - a model defined in Swagger
 
         :param action_id: The action_id of this ActionMapping.  # noqa: E501
@@ -32,6 +33,8 @@ class ActionMapping(Model):
         :type character_id: str
         :param intent_action: The intent_action of this ActionMapping.  # noqa: E501
         :type intent_action: bool
+        :param threat_state: The threat_state of this ActionMapping.  # noqa: E501
+        :type threat_state: ThreatState
         :param parameters: The parameters of this ActionMapping.  # noqa: E501
         :type parameters: Dict[str, str]
         :param probe_id: The probe_id of this ActionMapping.  # noqa: E501
@@ -54,6 +57,7 @@ class ActionMapping(Model):
             'repeatable': bool,
             'character_id': str,
             'intent_action': bool,
+            'threat_state': ThreatState,
             'parameters': Dict[str, str],
             'probe_id': str,
             'choice': str,
@@ -70,6 +74,7 @@ class ActionMapping(Model):
             'repeatable': 'repeatable',
             'character_id': 'character_id',
             'intent_action': 'intent_action',
+            'threat_state': 'threat_state',
             'parameters': 'parameters',
             'probe_id': 'probe_id',
             'choice': 'choice',
@@ -84,6 +89,7 @@ class ActionMapping(Model):
         self._repeatable = repeatable
         self._character_id = character_id
         self._intent_action = intent_action
+        self._threat_state = threat_state
         self._parameters = parameters
         self._probe_id = probe_id
         self._choice = choice
@@ -244,6 +250,27 @@ class ActionMapping(Model):
         """
 
         self._intent_action = intent_action
+
+    @property
+    def threat_state(self) -> ThreatState:
+        """Gets the threat_state of this ActionMapping.
+
+
+        :return: The threat_state of this ActionMapping.
+        :rtype: ThreatState
+        """
+        return self._threat_state
+
+    @threat_state.setter
+    def threat_state(self, threat_state: ThreatState):
+        """Sets the threat_state of this ActionMapping.
+
+
+        :param threat_state: The threat_state of this ActionMapping.
+        :type threat_state: ThreatState
+        """
+
+        self._threat_state = threat_state
 
     @property
     def parameters(self) -> Dict[str, str]:


### PR DESCRIPTION
ADEPT would like to be able to convey to an ADM that there is an expected change in threat level if a particular action is performed.

Work performed:
- Added `threat_state` to the action mappings (which means they’ll also have to be in the `Action` class so that ADMs see it.  The `threat_state` will be ignored by the server for incoming actions.
- Updated sample YAML to show usage of this feature.

Use with client branch [ITM-439](https://github.com/NextCenturyCorporation/itm-evaluation-client/tree/ITM-439) and its corresponding [PR](https://github.com/NextCenturyCorporation/itm-evaluation-client/pull/40).

To test, use `itm_human_input.py`:
* `python itm_human_input.py --session test --scenario sample-1`
* Type `s` and `c` to start the scenario.
  * Ensure there is one `aid_delay` object in the state.
* Type `v` and `t` to take an action.  Select the `treat-civ` action ID to move to the next scene
  * Ensure there are now two `aid_delay` objects in the state.
* Type `v` to get a(v)ailable actions.
  * Ensure that the ground-based `MOVE_TO_EVAC` actions have a `threat_state` associated with them.
* If you wish, type `i` to (i)ntend an action and select one of the `MOVE_TO_EVAC` options, then end the scene.

Feel free to try anything else you like, including running 100 test sessions with `--count 100`.

[ITM-439]: https://nextcentury.atlassian.net/browse/ITM-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ