### PR TITLE
ITM-461

### DIFF
--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -100,8 +100,6 @@ class ITMScenario:
         # If in training mode, record probe response in meta info
         if self.session.kdma_training:
             self.session.state.meta_info.probe_response = response
-            print("Probe response in meta info:")
-            print(self.session.state.meta_info.probe_response)
 
         self.session.history.add_history(
             "Respond to TA1 Probe",
@@ -218,15 +216,6 @@ class ITMScenario:
 
             # 1a. Remove `removed_characters`, even if in configured scene state.
             if getattr(self.isd.current_scene, 'removed_characters', None) and len(self.isd.current_scene.removed_characters) > 0:
-                current_state.characters = [
-                    character for character in current_state.characters
-                    if character.id not in self.isd.current_scene.removed_characters
-                ]
-                # if the target_state includes a character that is listed in removed_characters, that is a yaml misconfiguration
-                target_state.characters = [
-                    character for character in target_state.characters
-                    if character.id not in self.isd.current_scene.removed_characters
-                ]
                 filtered_out_characters = [
                     character for character in target_state.characters
                     if character.id in self.isd.current_scene.removed_characters
@@ -234,6 +223,18 @@ class ITMScenario:
 
                 if len(filtered_out_characters) > 0:
                     logging.warning("\033[92mScene configuration issue: target state includes character that was removed\033[00m")
+                
+                current_state.characters = [
+                    character for character in current_state.characters
+                    if character.id not in self.isd.current_scene.removed_characters
+                ]
+                logging.warning("Current characters after scene change")
+                logging.warning(current_state.characters)
+                # if the target_state includes a character that is listed in removed_characters, that is a yaml misconfiguration
+                target_state.characters = [
+                    character for character in target_state.characters
+                    if character.id not in self.isd.current_scene.removed_characters
+                ]
         else:
             current_state.characters = deepcopy(target_state.characters)
 
@@ -270,8 +271,6 @@ class ITMScenario:
         # 5. Update MetaInfo with new scene ID if training mode
         if self.session.kdma_training:
             current_state.meta_info.scene_id = self.isd.current_scene.id
-            print("Scene in meta info: ")
-            print(current_state.meta_info.scene_id)
 
 
     def update_property(self, current_state, target_state):

--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -74,6 +74,8 @@ class ITMScenario:
         for action in actions:
             if not getattr(action, 'character_id', None) or action.character_id in current_character_ids:
                 filtered_actions.append(action)
+            else:
+                pass # This an error condition that will be flagged when changing scenes
 
         return filtered_actions
 
@@ -221,8 +223,7 @@ class ITMScenario:
                     character for character in current_state.characters
                     if character.id not in self.isd.current_scene.removed_characters
                 ]
-                logging.warning("Current characters after scene change")
-                logging.warning(current_state.characters)
+
                 # if the target_state includes a character that is listed in removed_characters, that is a yaml misconfiguration
                 target_state.characters = [
                     character for character in target_state.characters

--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -70,17 +70,10 @@ class ITMScenario:
 
         # safe guarding that an action with character id of a removed character doesn't slip through the cracks
         filtered_actions = []
-        filtered_out_actions = []
 
         for action in actions:
             if not getattr(action, 'character_id', None) or action.character_id in current_character_ids:
                 filtered_actions.append(action)
-            else:
-                filtered_out_actions.append(action)
-        
-        # if actions are filtered out, that means there is a configuration issue in yaml file of available action to character not in scene
-        if filtered_out_actions:
-            logging.warning("\033[92mScene configuration issue: ignoring actions with an invalid character: %s\033[00m", filtered_out_actions)
 
         return filtered_actions
 


### PR DESCRIPTION
[ITM-461](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&selectedIssue=ITM-461)

Before the warning log would never appear because the removed characters were filtered out before checking if there was a matching character id in the `target_state` (so the list was always empty). I am checking for matching character id's in the `target_state` and `removed_characters` before filtering them out to trigger a warning log. The character will still be removed from the scene. To test, I used the `removed_characters.yaml` file. You'll see that when we transition into the second scene (scene.id: 1), Mike is listed as a character in the target state as well as in `removed_characters`. The sever should warn that this is a misconfiguration and then still remove him from the scene. I have added an additional log for testing that will list the current characters when the scene changes. For this test file the characters after the scene change should be: `Civilian_01` and `Captain_01`

There are no changes to the client, so testing with the client's dev branch is fine.

`python itm_minimal_runner.py --name foobar --session test --scenario removed_characters`

Ensure that you can see the proper logs, `itm_human_input.py` could be used for more in-depth testing.

[ITM-461]: https://nextcentury.atlassian.net/browse/ITM-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ