### PR TITLE
ITM-485: Miscellaneous late requested changes

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -708,13 +708,13 @@ components:
           minimum: 0
         type:
           $ref: "#/components/schemas/AidTypeEnum"
-        level:
+        role:
           type: integer
           description: >
-            Refers to the kinds of resources/capabilities available in a trauma center; Level 1 has more resources than Level 5.
-            See [amtrauma.org](https://www.amtrauma.org/page/traumalevels/)
+            The characterization of health support for the distribution of medical resources and capabilities; Role 1 has higher capability than Role 4.
+            See [health.mil](https://health.mil/Reference-Center/Glossary-Terms/2018/06/22/Roles-of-Medical-Care)
           minimum: 1
-          maximum: 5
+          maximum: 4
         patients_treated:
           type: array
           description: "A list of types of patients that can be helped; if omitted, then no restrictions or restrictions are irrelevant"
@@ -774,6 +774,10 @@ components:
         object:
           type: string
           description: "The 'object' of the event; can be a character `id` or an `EntityTypeEnum`"
+        when:
+          type: number
+          format: float
+          description: "indicates when (in minutes) the event happened (negative value) or is expected to happen (positive value); omit if zero (event happens now)"
         action_id:
           type: string
           description: An action ID from among the available actions

--- a/swagger_server/itm/data/metrics/test/sample.yaml
+++ b/swagger_server/itm/data/metrics/test/sample.yaml
@@ -42,7 +42,7 @@ state:
         - id: air_evac
           delay: 5 # Time until aid is available, in minutes; 0 means ready now
           type: air evac # controlled vocab includes local military, local non-military, air evac, ground evac, water evac, unknown evac
-          level: 2 # Refers to the kinds of resources/capabilities available in a trauma center; Level 1 has more resources than Level 5 (see https://www.amtrauma.org/page/traumalevels/).
+          role: 2 # The characterization of health support for the distribution of medical resources and capabilities; Role 1 has higher capability than Role 4. (see https://health.mil/Reference-Center/Glossary-Terms/2018/06/22/Roles-of-Medical-Care).
           patients_treated: # A list of types of patients that can be helped; if omitted, then no restrictions or restrictions are irrelevant
             - Allied
             - Allied US
@@ -401,17 +401,17 @@ scenes:
             You can also try to evac one casualty by ground immediately, but you're more likely to encounter hostiles.
           aid:
             - id: air_evac # Notice that when you update an aid entry, you must also include unchanged parameters
-              delay: 50
-              type: air evac
-              level: 2
-              patients_treated:
+              delay: 50 # Time until aid is available, in minutes; 0 means ready now
+              type: air evac # controlled vocab includes local military, local non-military, air evac, ground evac, water evac, unknown evac
+              role: 2 # The characterization of health support for the distribution of medical resources and capabilities; Role 1 has higher capability than Role 4. (see https://health.mil/Reference-Center/Glossary-Terms/2018/06/22/Roles-of-Medical-Care).
+              patients_treated: # A list of types of patients that can be helped; if omitted, then no restrictions or restrictions are irrelevant
                 - Allied
                 - Allied US
               max_transport: 3
             - id: ground_evac
-              delay: 0
-              type: ground evac
-              max_transport: 1
+              delay: 0 # Time until aid is available, in minutes; 0 means ready now
+              type: ground evac # controlled vocab includes local military, local non-military, air evac, ground evac, water evac, unknown evac
+              max_transport: 1 # Maximum number of casualties that can be accommodated
     probe_config:
       - probe_id: adept-september-demo-probe-5
         description: Evacuation probe

--- a/swagger_server/models/aid.py
+++ b/swagger_server/models/aid.py
@@ -16,7 +16,7 @@ class Aid(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, id: str=None, delay: float=None, type: AidTypeEnum=None, level: int=None, patients_treated: List[MilitaryDispositionEnum]=None, max_transport: int=None):  # noqa: E501
+    def __init__(self, id: str=None, delay: float=None, type: AidTypeEnum=None, role: int=None, patients_treated: List[MilitaryDispositionEnum]=None, max_transport: int=None):  # noqa: E501
         """Aid - a model defined in Swagger
 
         :param id: The id of this Aid.  # noqa: E501
@@ -25,8 +25,8 @@ class Aid(Model):
         :type delay: float
         :param type: The type of this Aid.  # noqa: E501
         :type type: AidTypeEnum
-        :param level: The level of this Aid.  # noqa: E501
-        :type level: int
+        :param role: The role of this Aid.  # noqa: E501
+        :type role: int
         :param patients_treated: The patients_treated of this Aid.  # noqa: E501
         :type patients_treated: List[MilitaryDispositionEnum]
         :param max_transport: The max_transport of this Aid.  # noqa: E501
@@ -36,7 +36,7 @@ class Aid(Model):
             'id': str,
             'delay': float,
             'type': AidTypeEnum,
-            'level': int,
+            'role': int,
             'patients_treated': List[MilitaryDispositionEnum],
             'max_transport': int
         }
@@ -45,14 +45,14 @@ class Aid(Model):
             'id': 'id',
             'delay': 'delay',
             'type': 'type',
-            'level': 'level',
+            'role': 'role',
             'patients_treated': 'patients_treated',
             'max_transport': 'max_transport'
         }
         self._id = id
         self._delay = delay
         self._type = type
-        self._level = level
+        self._role = role
         self._patients_treated = patients_treated
         self._max_transport = max_transport
 
@@ -139,27 +139,27 @@ class Aid(Model):
         self._type = type
 
     @property
-    def level(self) -> int:
-        """Gets the level of this Aid.
+    def role(self) -> int:
+        """Gets the role of this Aid.
 
-        Refers to the kinds of resources/capabilities available in a trauma center; Level 1 has more resources than Level 5. See [amtrauma.org](https://www.amtrauma.org/page/traumalevels/)   # noqa: E501
+        The characterization of health support for the distribution of medical resources and capabilities; Role 1 has higher capability than Role 4. See [health.mil](https://health.mil/Reference-Center/Glossary-Terms/2018/06/22/Roles-of-Medical-Care)   # noqa: E501
 
-        :return: The level of this Aid.
+        :return: The role of this Aid.
         :rtype: int
         """
-        return self._level
+        return self._role
 
-    @level.setter
-    def level(self, level: int):
-        """Sets the level of this Aid.
+    @role.setter
+    def role(self, role: int):
+        """Sets the role of this Aid.
 
-        Refers to the kinds of resources/capabilities available in a trauma center; Level 1 has more resources than Level 5. See [amtrauma.org](https://www.amtrauma.org/page/traumalevels/)   # noqa: E501
+        The characterization of health support for the distribution of medical resources and capabilities; Role 1 has higher capability than Role 4. See [health.mil](https://health.mil/Reference-Center/Glossary-Terms/2018/06/22/Roles-of-Medical-Care)   # noqa: E501
 
-        :param level: The level of this Aid.
-        :type level: int
+        :param role: The role of this Aid.
+        :type role: int
         """
 
-        self._level = level
+        self._role = role
 
     @property
     def patients_treated(self) -> List[MilitaryDispositionEnum]:

--- a/swagger_server/models/event.py
+++ b/swagger_server/models/event.py
@@ -15,7 +15,7 @@ class Event(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, unstructured: str=None, type: EventTypeEnum=None, source: str=None, object: str=None, action_id: str=None, relevant_state: List[str]=None):  # noqa: E501
+    def __init__(self, unstructured: str=None, type: EventTypeEnum=None, source: str=None, object: str=None, when: float=None, action_id: str=None, relevant_state: List[str]=None):  # noqa: E501
         """Event - a model defined in Swagger
 
         :param unstructured: The unstructured of this Event.  # noqa: E501
@@ -26,6 +26,8 @@ class Event(Model):
         :type source: str
         :param object: The object of this Event.  # noqa: E501
         :type object: str
+        :param when: The when of this Event.  # noqa: E501
+        :type when: float
         :param action_id: The action_id of this Event.  # noqa: E501
         :type action_id: str
         :param relevant_state: The relevant_state of this Event.  # noqa: E501
@@ -36,6 +38,7 @@ class Event(Model):
             'type': EventTypeEnum,
             'source': str,
             'object': str,
+            'when': float,
             'action_id': str,
             'relevant_state': List[str]
         }
@@ -45,6 +48,7 @@ class Event(Model):
             'type': 'type',
             'source': 'source',
             'object': 'object',
+            'when': 'when',
             'action_id': 'action_id',
             'relevant_state': 'relevant_state'
         }
@@ -52,6 +56,7 @@ class Event(Model):
         self._type = type
         self._source = source
         self._object = object
+        self._when = when
         self._action_id = action_id
         self._relevant_state = relevant_state
 
@@ -159,6 +164,29 @@ class Event(Model):
         """
 
         self._object = object
+
+    @property
+    def when(self) -> float:
+        """Gets the when of this Event.
+
+        indicates when (in minutes) the event happened (negative value) or is expected to happen (positive value); omit if zero (event happens now)  # noqa: E501
+
+        :return: The when of this Event.
+        :rtype: float
+        """
+        return self._when
+
+    @when.setter
+    def when(self, when: float):
+        """Sets the when of this Event.
+
+        indicates when (in minutes) the event happened (negative value) or is expected to happen (positive value); omit if zero (event happens now)  # noqa: E501
+
+        :param when: The when of this Event.
+        :type when: float
+        """
+
+        self._when = when
 
     @property
     def action_id(self) -> str:


### PR DESCRIPTION
- Add 'when' parameter to events;
- Rename trauma level (1-5) to medical role (1-4) based on different resource
   - e.g., `Aid.level` -> `Aid.role`