### PR TITLE
ITM-509: Allow CHECK_ALL_VITALS when no pulse ox, but don't check blood ox

### DIFF
--- a/swagger_server/itm/itm_scenario_reader.py
+++ b/swagger_server/itm/itm_scenario_reader.py
@@ -38,7 +38,7 @@ class ITMScenarioReader:
         Args:
             yaml_path: The file path to the YAML data.
         """
-        with open(yaml_path, 'r') as file:
+        with open(yaml_path, 'r', encoding='utf-8') as file:
             self.yaml_data = yaml.safe_load(file)
 
     def read_scenario_from_yaml(self) -> Tuple[Scenario, List[ITMScene]]:


### PR DESCRIPTION
If there is no pulse oximeter in the state, then `CHECK_ALL_VITALS` is allowed/valid, but blood oxygen won’t be returned.

See trivial, documentation-only [client PR](https://github.com/NextCenturyCorporation/itm-evaluation-client/pull/51)

To test:
- Run a `test` session via the `itm_minimal_runner` in the client repo; it should complete normally.
- Switch to `development` branch.
  - Change "dryrun" to "metrics" in `itm_session` line 29.
  - Run a "soartech" session via the `itm_minimal_runner` in the client repo; note error.
- Switch back to `ITM-509` branch.
  - Change "dryrun" to "metrics" in `itm_session` line 29.
  - Run a "soartech" session via the `itm_minimal_runner` in the client repo; this time it should work.