### PR TITLE
ITM-512

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ swagger_server/api
 
 # local history output
 itm_history_output
+
+# local config files
+config.ini

--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ On Windows, the method to activate depends on the shell:
 - PowerShell: `venv\Scripts\Activate.ps1`
 - cmd.exe: `venv\Scripts\activate.bat`
 
+
+## Configuration
+
+Rename `config.ini.template` file to `config.ini`. 
+
+The following properties can be configured:
+- `EVALUATION_TYPE` 
+    - default is `dryrun`
+- `SCENARIO_DIRECTORY`
+    - default is `swagger_server/itm/data/%(EVALUATION_TYPE)s/scenarios/`
+
+*NOTE:* the trailing **`s`** in `.../data/%(EVALUATION_TYPE)s/...` is needed for string interpolation to work properly.
+
 ## Usage
 To run the server, please execute the following from the root directory:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rename `config.ini.template` file to `config.ini`.
 
 The following properties can be configured:
 - `EVALUATION_TYPE` 
-    - default is `dryrun`
+    - default is `dryrun` but `metrics` is also supported
 - `SCENARIO_DIRECTORY`
     - default is `swagger_server/itm/data/%(EVALUATION_TYPE)s/scenarios/`
 

--- a/swagger_server/config.ini.template
+++ b/swagger_server/config.ini.template
@@ -1,0 +1,7 @@
+; Copy over this template file and rename it to config.ini
+; Replace the default configurations below with the desired values
+
+[DEFAULT]
+
+EVALUATION_TYPE=dryrun
+SCENARIO_DIRECTORY=swagger_server/itm/data/%(EVALUATION_TYPE)s/

--- a/swagger_server/config.ini.template
+++ b/swagger_server/config.ini.template
@@ -4,4 +4,4 @@
 [DEFAULT]
 
 EVALUATION_TYPE=dryrun
-SCENARIO_DIRECTORY=swagger_server/itm/data/%(EVALUATION_TYPE)s/
+SCENARIO_DIRECTORY=swagger_server/itm/data/%(EVALUATION_TYPE)s/scenarios/

--- a/swagger_server/config_util.py
+++ b/swagger_server/config_util.py
@@ -1,6 +1,6 @@
 import os
 from os.path import exists
-from configparser import ConfigParser, NoOptionError
+from configparser import ConfigParser
 from dataclasses import dataclass
 from typing import Optional
 

--- a/swagger_server/config_util.py
+++ b/swagger_server/config_util.py
@@ -1,0 +1,36 @@
+import os
+from os.path import exists
+from configparser import ConfigParser,NoOptionError
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class config_data:
+    success: bool
+    data: dict
+    source_path: Optional[str] = None
+
+def read_ini(default_path='swagger_server/config.ini'):
+    path = os.path.expanduser(default_path)
+    parser = ConfigParser()
+    parser.read(path)
+    return (parser,path)
+
+def check_ini():
+    keys_values = {}
+    parser_path = read_ini()
+    ini = parser_path[0]
+    final_path = parser_path[1]
+    if exists(final_path):
+        keys = ("EVALUATION_TYPE", "SCENARIO_DIRECTORY")
+        for option in keys:
+            if option in ini["DEFAULT"]:#checks if "option" key exists in "default" section
+                key_value = ini.get("DEFAULT", option)
+                keys_values.setdefault(option,key_value)
+            else: 
+                raise Exception(f"We couldn't find this key in your file:{option}")
+    else:
+        raise FileNotFoundError(f"Couldn't find file: {os.path.abspath(final_path)}")
+            
+    return config_data(True,keys_values,final_path)
+

--- a/swagger_server/config_util.py
+++ b/swagger_server/config_util.py
@@ -1,6 +1,6 @@
 import os
 from os.path import exists
-from configparser import ConfigParser,NoOptionError
+from configparser import ConfigParser, NoOptionError
 from dataclasses import dataclass
 from typing import Optional
 
@@ -24,13 +24,13 @@ def check_ini():
     if exists(final_path):
         keys = ("EVALUATION_TYPE", "SCENARIO_DIRECTORY")
         for option in keys:
-            if option in ini["DEFAULT"]:#checks if "option" key exists in "default" section
+            if option in ini["DEFAULT"]: # checks if "option" key exists in "default" section
                 key_value = ini.get("DEFAULT", option)
-                keys_values.setdefault(option,key_value)
+                keys_values.setdefault(option, key_value)
             else: 
-                raise Exception(f"We couldn't find this key in your file:{option}")
+                raise Exception(f"Couldn't find key {option} in this file")
     else:
         raise FileNotFoundError(f"Couldn't find file: {os.path.abspath(final_path)}")
             
-    return config_data(True,keys_values,final_path)
+    return config_data(True, keys_values, final_path)
 

--- a/swagger_server/config_util.py
+++ b/swagger_server/config_util.py
@@ -14,7 +14,7 @@ def read_ini(default_path='swagger_server/config.ini'):
     path = os.path.expanduser(default_path)
     parser = ConfigParser()
     parser.read(path)
-    return (parser,path)
+    return (parser, path)
 
 def check_ini():
     keys_values = {}

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -490,8 +490,8 @@ class ITMSession:
             while len(self.itm_scenarios) < max_scenarios:
                 random_index = random.randint(0, num_read_scenarios - 1)
                 self.itm_scenarios.append(deepcopy(self.itm_scenarios[random_index]))
-
-        logging.info('Loaded %d total scenarios from %s.', len(self.itm_scenarios), ITMSession.SCENARIO_DIRECTORY)
+                
+        logging.info('Loaded %d total scenarios from %s.', len(self.itm_scenarios), f"swagger_server/itm/data/{ITMSession.EVALUATION_TYPE}/test/" if self.session_type == 'test' else ITMSession.SCENARIO_DIRECTORY)
         self.current_scenario_index = 0
 
         return self.session_id

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -40,7 +40,7 @@ class ITMSession:
     def __init__(self):
         """
         Initialize an ITMSession.
-        """ 
+        """
         self.session_id = None
         self.adm_name = ''
         self.adm_profile = ''

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -452,7 +452,7 @@ class ITMSession:
                 self._end_session() # Exception here ends the session
                 return 'Exception communicating with TA1; is the TA1 server running?  Ending session.', 503
 
-        path = f"{ITMSession.SCENARIO_DIRECTORY}" + ("test/" if self.session_type == 'test' else 'scenarios/')
+        path = f"swagger_server/itm/data/{ITMSession.EVALUATION_TYPE}/test/" if self.session_type == 'test' else f"{ITMSession.SCENARIO_DIRECTORY}/"
         num_read_scenarios = 0
         for ta1_name in ta1_names:
             if self.session_type == 'test':
@@ -491,7 +491,7 @@ class ITMSession:
                 random_index = random.randint(0, num_read_scenarios - 1)
                 self.itm_scenarios.append(deepcopy(self.itm_scenarios[random_index]))
 
-        logging.info('Loaded %d total scenarios.', len(self.itm_scenarios))
+        logging.info('Loaded %d total scenarios from %s.', len(self.itm_scenarios), ITMSession.SCENARIO_DIRECTORY)
         self.current_scenario_index = 0
 
         return self.session_id

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -31,7 +31,7 @@ class ITMSession:
     
     # Class variables
     EVALUATION_TYPE = config['DEFAULT']['EVALUATION_TYPE']
-    SCENARIO_DIRECTORY =config['DEFAULT']['SCENARIO_DIRECTORY']
+    SCENARIO_DIRECTORY = config['DEFAULT']['SCENARIO_DIRECTORY']
     local_alignment_targets = {} # alignment_targets baked into server, for use when not connecting to TA1
     alignment_data = {} # maps ta1_name to list alignment_targets, used whether connecting to TA1 or not
     ta1_controllers = {} # map of ta1_names to lists of ta1_controllers

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -20,13 +20,18 @@ from .itm_action_handler import ITMActionHandler
 from .itm_alignment_target_reader import ITMAlignmentTargetReader
 from .itm_ta1_controller import ITMTa1Controller
 from .itm_history import ITMHistory
+from swagger_server import config_util
 
 class ITMSession:
     """
     Class for representing and manipulating a simulation scenario session.
     """
+    config_util.check_ini()
+    config = config_util.read_ini()[0]
+    
     # Class variables
-    EVALUATION_TYPE = 'dryrun'
+    EVALUATION_TYPE = config['DEFAULT']['EVALUATION_TYPE']
+    SCENARIO_DIRECTORY =config['DEFAULT']['SCENARIO_DIRECTORY']
     local_alignment_targets = {} # alignment_targets baked into server, for use when not connecting to TA1
     alignment_data = {} # maps ta1_name to list alignment_targets, used whether connecting to TA1 or not
     ta1_controllers = {} # map of ta1_names to lists of ta1_controllers
@@ -35,7 +40,7 @@ class ITMSession:
     def __init__(self):
         """
         Initialize an ITMSession.
-        """
+        """ 
         self.session_id = None
         self.adm_name = ''
         self.adm_profile = ''
@@ -447,7 +452,7 @@ class ITMSession:
                 self._end_session() # Exception here ends the session
                 return 'Exception communicating with TA1; is the TA1 server running?  Ending session.', 503
 
-        path = f"swagger_server/itm/data/{ITMSession.EVALUATION_TYPE}/" + ("test/" if self.session_type == 'test' else 'scenarios/')
+        path = f"{ITMSession.SCENARIO_DIRECTORY}" + ("test/" if self.session_type == 'test' else 'scenarios/')
         num_read_scenarios = 0
         for ta1_name in ta1_names:
             if self.session_type == 'test':


### PR DESCRIPTION
Created a `config_util` class that handles:

- checking to make sure the config file exists 
- reading in the config file
- verifying the expected keys are in the config file

Added a `.template` version of the config.ini so that each user can create their own config.ini file and not get it overwritten by different commits. In order to get it working, copy over the `config.ini.template` file, renaming it to `config.ini`