### PR TITLE
ITM-520: Return scene ID in state in all session types

### DIFF
--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -179,7 +179,7 @@ class ITMScenario:
         3. For everything else, replace any specified (non-None) values
            3a. Lists are copied whole (e.g., `character_importance`, `aid`, `threats`).
         4. Clear hidden data (e.g., character vitals)
-        5. Update MetaInfo with new scene ID if training mode
+        5. Update MetaInfo with new scene ID
         '''
         # Rule 0: Abort if no state to merge
         if not target_state:
@@ -263,9 +263,8 @@ class ITMScenario:
         # 4. Clear hidden data (e.g., character vitals)
         ITMScenario.clear_hidden_data(current_state)
 
-        # 5. Update MetaInfo with new scene ID if training mode
-        if self.session.kdma_training:
-            current_state.meta_info.scene_id = self.isd.current_scene.id
+        # 5. Update MetaInfo with new scene ID
+        current_state.meta_info.scene_id = self.isd.current_scene.id
 
 
     def update_property(self, current_state, target_state):

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -352,7 +352,7 @@ class ITMSession:
                     self.history.add_history(
                         "TA1 Session ID", {}, ta1_session_id
                     )
-                    logging.info("Got new session_id `%s` from TA1.", ta1_session_id)
+                    logging.info("Got new session_id '%s' from TA1.", ta1_session_id)
                 except:
                     logging.exception("Exception communicating with TA1; is the TA1 server running?  Ending session.")
                     self._end_session() # Exception here ends the session

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -331,8 +331,7 @@ class ITMSession:
         try:
             self.state = deepcopy(self.itm_scenario.isd.current_scene.state)
             ITMScenario.clear_hidden_data(self.state)
-            if self.kdma_training:
-                self.state.meta_info = MetaInfo(scene_id=self.itm_scenario.isd.current_scene.id, probe_response=None)
+            self.state.meta_info = MetaInfo(scene_id=self.itm_scenario.isd.current_scene.id, probe_response=None)
             scenario = Scenario(
                 id=self.itm_scenario.id,
                 name=self.itm_scenario.name,
@@ -353,7 +352,7 @@ class ITMSession:
                     self.history.add_history(
                         "TA1 Session ID", {}, ta1_session_id
                     )
-                    logging.info("Got new session_id from TA1.", ta1_session_id)
+                    logging.info("Got new session_id `%s` from TA1.", ta1_session_id)
                 except:
                     logging.exception("Exception communicating with TA1; is the TA1 server running?  Ending session.")
                     self._end_session() # Exception here ends the session


### PR DESCRIPTION
Easiest way to test is with `itm_human_input.py` (make sure the scene id is there, but no probe response), or print out the state after an action in the minimal runner.  Use a test session with `--scenario sample-1`.