### PR TITLE
ITM-478/521/522:  Integrate with TA1 Dry Run servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ itm_history_output
 
 # local config files
 config.ini
+
+# local scenarios
+scenarios
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ The following properties can be configured:
 
 *NOTE:* the trailing **`s`** in `.../data/%(EVALUATION_TYPE)s/...` is needed for string interpolation to work properly.
 
+### Scenario filename convention
+Scenario files must be named in the following format to be read by the server at runtime (without punctuation except the indicated hyphens).
+This is the same convention used in the metrics evaluation:
+- `<EVALUATION_TYPE>-<ta1name>-[eval|train]-<id>.yaml`
+
+Please note:
+1. `EVALUATION_TYPE` is the value of the configuration variable defined in `config.ini`;
+2. `ta1name` is either `soartech` or `adept`;
+3. Use `eval` for evaluation scenarios and `train` for training scenarios; and
+4. The `id` should be derived from the scenario ID in the YAML file, although it isn't required, e.g., `qol`, `MJ2`, `urban`, etc.
+
 ## Usage
 To run the server, please execute the following from the root directory:
 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -435,7 +435,6 @@ components:
         - alignment_source
         - alignment_target_id
         - score
-        - kdma_values
       type: object
       description: Computed KDMA profile and alignment score for a set of decisions.
       properties:
@@ -454,12 +453,6 @@ components:
           description: Measured alignment, 0 (completely unaligned) - 1 (completely aligned).
           minimum: 0
           maximum: 1
-        kdma_values:
-          title: Kdma Values
-          type: array
-          items:
-            "$ref": "#/components/schemas/KDMA_Value"
-          description: Computed KDMA profile from results
     AlignmentSource:
       title: AlignmentSource
       required:

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/adept/ingroup_bias_1.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/adept/ingroup_bias_1.yaml
@@ -1,5 +1,5 @@
 # globally unique alignment target
-id: ingroup-bias-1
+id: ADEPT-DryRun-Ingroup Bias-0.1
 
 # list of KDMAs to align to
 # {kdma: str name, value: float target value}

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/adept/ingroup_bias_5.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/adept/ingroup_bias_5.yaml
@@ -1,5 +1,5 @@
 # globally unique alignment target
-id: ingroup-bias-5
+id: ADEPT-DryRun-Ingroup Bias-0.5
 
 # list of KDMAs to align to
 # {kdma: str name, value: float target value}

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/adept/ingroup_bias_9.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/adept/ingroup_bias_9.yaml
@@ -1,5 +1,5 @@
 # globally unique alignment target
-id: ingroup-bias-9
+id: ADEPT-DryRun-Ingroup Bias-0.9
 
 # list of KDMAs to align to
 # {kdma: str name, value: float target value}

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/adept/moral_judgement_1.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/adept/moral_judgement_1.yaml
@@ -1,5 +1,5 @@
 # globally unique alignment target
-id: moral-judgement-1
+id: ADEPT-DryRun-Moral judgement-0.1
 
 # list of KDMAs to align to
 # {kdma: str name, value: float target value}

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/adept/moral_judgement_5.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/adept/moral_judgement_5.yaml
@@ -1,5 +1,5 @@
 # globally unique alignment target
-id: moral-judgement-5
+id: ADEPT-DryRun-Moral judgement-0.5
 
 # list of KDMAs to align to
 # {kdma: str name, value: float target value}

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/adept/moral_judgement_9.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/adept/moral_judgement_9.yaml
@@ -1,5 +1,5 @@
 # globally unique alignment target
-id: moral-judgement-9
+id: ADEPT-DryRun-Moral judgement-0.9
 
 # list of KDMAs to align to
 # {kdma: str name, value: float target value}

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/qol_1.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/qol_1.yaml
@@ -1,4 +1,4 @@
 id: qol_1
 kdma_values:
-  - kdma: quality of life
+  - kdma: QualityOfLife
     value: 0.1

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/qol_5.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/qol_5.yaml
@@ -1,4 +1,4 @@
 id: qol_5
 kdma_values:
-  - kdma: quality of life
+  - kdma: QualityOfLife
     value: 0.5

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/qol_9.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/qol_9.yaml
@@ -1,4 +1,4 @@
 id: qol_9
 kdma_values:
-  - kdma: quality of life
+  - kdma: QualityOfLife
     value: 0.9

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/vol_1.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/vol_1.yaml
@@ -1,4 +1,4 @@
 id: vol_1
 kdma_values:
-  - kdma: value of life
+  - kdma: PerceivedQuantityOfLivesSaved
     value: 0.1

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/vol_5.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/vol_5.yaml
@@ -1,4 +1,4 @@
 id: vol_5
 kdma_values:
-  - kdma: value of life
+  - kdma: PerceivedQuantityOfLivesSaved
     value: 0.5

--- a/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/vol_9.yaml
+++ b/swagger_server/itm/data/dryrun/local_alignment_targets/soartech/vol_9.yaml
@@ -1,4 +1,4 @@
 id: vol_9
 kdma_values:
-  - kdma: value of life
+  - kdma: PerceivedQuantityOfLivesSaved
     value: 0.9

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -211,7 +211,7 @@ class ITMActionHandler:
                 return False, f'Malformed {action.action_type} Action: action_id `{action.action_id}` is not a valid action_id from the current scene', 400
         elif action.action_type == ActionTypeEnum.MOVE_TO:
             # Can only target unseen characters
-            if not action.intent_action and not character.unseen:
+            if not character.unseen:
                 return False, f'Can only perform {action.action_type} action with unseen characters, but `{action.character_id}` is not unseen', 400
         elif action.action_type == ActionTypeEnum.MOVE_TO_EVAC:
             # Requires aid_id parameter

--- a/swagger_server/itm/itm_scene.py
+++ b/swagger_server/itm/itm_scene.py
@@ -5,7 +5,7 @@ from random import shuffle
 from inspect import signature
 from typing import List
 from swagger_server.models import (
-    Action, ActionMapping, ActionTypeEnum, Character, Conditions, Scene, SemanticTypeEnum, State, Supplies, SupplyTypeEnum
+    Action, ActionMapping, ActionTypeEnum, Conditions, Scene, SemanticTypeEnum, State, Supplies, SupplyTypeEnum
 )
 from swagger_server.util import get_swagger_class_enum_values
 

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -63,7 +63,7 @@ class ITMSession:
         # ADM History
         self.history: ITMHistory = ITMHistory()
         # This determines whether the server makes calls to TA1
-        self.ta1_integration = True # Default here applies to non-training, non-eval sessions
+        self.ta1_integration = False # Default here applies to non-training, non-eval sessions
         # This determines whether the server returns history in final State after each scenario completes
         self.return_scenario_history = False
         # This determines whether the server saves history to JSON

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import List
 from copy import deepcopy
 from json import dumps
+from requests import exceptions
 from swagger_server.models import (
     Action,
     AlignmentTarget,
@@ -62,7 +63,7 @@ class ITMSession:
         # ADM History
         self.history: ITMHistory = ITMHistory()
         # This determines whether the server makes calls to TA1
-        self.ta1_integration = False # Default here applies to non-training, non-eval sessions
+        self.ta1_integration = True # Default here applies to non-training, non-eval sessions
         # This determines whether the server returns history in final State after each scenario completes
         self.return_scenario_history = False
         # This determines whether the server saves history to JSON
@@ -161,11 +162,13 @@ class ITMSession:
                     "target_id": self.itm_scenario.ta1_controller.alignment_target_id},
                     session_alignment.to_dict()
                 )
-                self.itm_scenario.id(f"Got session alignment score %s from TA1.", session_alignment_score)
+                logging.info("Got session alignment score %s from TA1.", session_alignment_score)
                 alignment_scenario_id = session_alignment.alignment_source[0].scenario_id
                 if self.itm_scenario.id != alignment_scenario_id:
                     logging.error("\033[92mContamination in session_alignment! scenario is %s but alignment source scenario is %s.\033[00m",
                                     self.itm_scenario.id, alignment_scenario_id)
+            except exceptions.HTTPError:
+                logging.exception("HTTPError from TA1 getting session alignment.")
             except Exception:
                 logging.exception("Exception getting session alignment. Ignoring.")
 
@@ -178,7 +181,9 @@ class ITMSession:
 
     def _cleanup(self):
         if self.save_history:
-            alignment_type = 'high' if 'high' in self.itm_scenario.alignment_target.id.lower() else 'low'
+            kdma = self.itm_scenario.alignment_target.kdma_values[0]['kdma'].split(" ")[0].lower()
+            value = self.itm_scenario.alignment_target.kdma_values[0]['value']
+            alignment_type = kdma + "-" + str(value)
             timestamp = f"{datetime.now():%b%d-%H.%M.%S}" # e.g., "jungle-1-soartech-high-Mar13-11.44.44"
             filename = f"{self.itm_scenario.id.replace(' ', '_')}-{self.itm_scenario.scene_type}-{alignment_type}-{timestamp}"
             self.history.write_to_json_file(filename, self.save_history_to_s3)
@@ -353,6 +358,10 @@ class ITMSession:
                         "TA1 Session ID", {}, ta1_session_id
                     )
                     logging.info("Got new session_id '%s' from TA1.", ta1_session_id)
+                except exceptions.HTTPError:
+                    self._end_session() # Exception here ends the session
+                    logging.exception("HTTPError from TA1 starting session.")
+                    return 'Could not get new session.  Ending session.', 503
                 except:
                     logging.exception("Exception communicating with TA1; is the TA1 server running?  Ending session.")
                     self._end_session() # Exception here ends the session
@@ -415,6 +424,8 @@ class ITMSession:
         self.kdma_training = kdma_training
         self.adm_name = adm_name
         self.adm_profile = adm_profile if adm_profile else 'Unspecified'
+        if max_scenarios == 0:
+            max_scenarios = None
         self.itm_scenarios = []
         self.session_type = session_type
         self.history.clear_history()
@@ -570,14 +581,15 @@ class ITMSession:
                 if len(self.itm_scenario.probes_sent) > 0:
                     session_alignment = \
                         self.itm_scenario.ta1_controller.get_session_alignment(target_id=target_id)
+                    session_alignment.alignment_target_id = target_id
                 else:
-                    session_alignment = AlignmentResults(alignment_source=[], alignment_target_id=target_id, score=0.5, kdma_values=[])
+                    session_alignment = AlignmentResults(alignment_source=[], alignment_target_id=target_id, score=0.5)
 
             except:
                 logging.exception("Exception getting session alignment; is a TA1 server running?")
                 return 'Could not get session alignment; is a TA1 server running?', 503
         else:
-            session_alignment = AlignmentResults(alignment_source=[], alignment_target_id=target_id, score=0.5, kdma_values=[])
+            session_alignment = AlignmentResults(alignment_source=[], alignment_target_id=target_id, score=0.5)
         logging.info("Got session alignment score %f from TA1 for alignment target id %s.", session_alignment.score, target_id)
         return session_alignment
 

--- a/swagger_server/itm/itm_ta1_controller.py
+++ b/swagger_server/itm/itm_ta1_controller.py
@@ -46,7 +46,9 @@ class ITMTa1Controller:
 
     def new_session(self):
         url = f"http://{self.host}:{self.port}/api/v1/new_session"
-        response = self.to_dict(requests.post(url))
+        initial_response = requests.post(url)
+        initial_response.raise_for_status()
+        response = self.to_dict(initial_response)
         self.session_id = response
         return response
 
@@ -66,7 +68,9 @@ class ITMTa1Controller:
             "probe_id": probe_id
         }
         url = f"{base_url}?{urllib.parse.urlencode(params)}"
-        response = self.to_dict(requests.get(url))
+        initial_response = requests.get(url)
+        initial_response.raise_for_status()
+        response = self.to_dict(initial_response)
         return response
 
     def get_session_alignment(self, target_id = None):
@@ -76,5 +80,7 @@ class ITMTa1Controller:
             "target_id": self.alignment_target_id if not target_id else target_id
         }
         url = f"{base_url}?{urllib.parse.urlencode(params)}"
-        response = self.to_dict(requests.get(url))
+        initial_response = requests.get(url)
+        initial_response.raise_for_status()
+        response = self.to_dict(initial_response)
         return AlignmentResults.from_dict(response)

--- a/swagger_server/models/alignment_results.py
+++ b/swagger_server/models/alignment_results.py
@@ -7,7 +7,6 @@ from typing import List, Dict  # noqa: F401
 
 from swagger_server.models.base_model_ import Model
 from swagger_server.models.alignment_source import AlignmentSource  # noqa: F401,E501
-from swagger_server.models.kdma_value import KDMAValue  # noqa: F401,E501
 from swagger_server import util
 
 
@@ -16,7 +15,7 @@ class AlignmentResults(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, alignment_source: List[AlignmentSource]=None, alignment_target_id: str=None, score: float=None, kdma_values: List[KDMAValue]=None):  # noqa: E501
+    def __init__(self, alignment_source: List[AlignmentSource]=None, alignment_target_id: str=None, score: float=None):  # noqa: E501
         """AlignmentResults - a model defined in Swagger
 
         :param alignment_source: The alignment_source of this AlignmentResults.  # noqa: E501
@@ -25,26 +24,21 @@ class AlignmentResults(Model):
         :type alignment_target_id: str
         :param score: The score of this AlignmentResults.  # noqa: E501
         :type score: float
-        :param kdma_values: The kdma_values of this AlignmentResults.  # noqa: E501
-        :type kdma_values: List[KDMAValue]
         """
         self.swagger_types = {
             'alignment_source': List[AlignmentSource],
             'alignment_target_id': str,
-            'score': float,
-            'kdma_values': List[KDMAValue]
+            'score': float
         }
 
         self.attribute_map = {
             'alignment_source': 'alignment_source',
             'alignment_target_id': 'alignment_target_id',
-            'score': 'score',
-            'kdma_values': 'kdma_values'
+            'score': 'score'
         }
         self._alignment_source = alignment_source
         self._alignment_target_id = alignment_target_id
         self._score = score
-        self._kdma_values = kdma_values
 
     @classmethod
     def from_dict(cls, dikt) -> 'AlignmentResults':
@@ -129,28 +123,3 @@ class AlignmentResults(Model):
             raise ValueError("Invalid value for `score`, must not be `None`")  # noqa: E501
 
         self._score = score
-
-    @property
-    def kdma_values(self) -> List[KDMAValue]:
-        """Gets the kdma_values of this AlignmentResults.
-
-        Computed KDMA profile from results  # noqa: E501
-
-        :return: The kdma_values of this AlignmentResults.
-        :rtype: List[KDMAValue]
-        """
-        return self._kdma_values
-
-    @kdma_values.setter
-    def kdma_values(self, kdma_values: List[KDMAValue]):
-        """Sets the kdma_values of this AlignmentResults.
-
-        Computed KDMA profile from results  # noqa: E501
-
-        :param kdma_values: The kdma_values of this AlignmentResults.
-        :type kdma_values: List[KDMAValue]
-        """
-        if kdma_values is None:
-            raise ValueError("Invalid value for `kdma_values`, must not be `None`")  # noqa: E501
-
-        self._kdma_values = kdma_values


### PR DESCRIPTION
- Removed `kdma_values` from `AlignmentResults`, in accordance with program changes. (ITM-478)
- Renamed various IDs to what TA1 is actually using (e.g., alignment targets, kdmas)
- Better handling/logging of TA1 server errors.
- Changed ADM output filenames since we're no longer using high/low
- Bugfixes.

To test, the best case scenario is to run the latest ADEPT and SoarTech servers and run the various session types against them.
If you haven't already, you'll have to copy the TA1 scenarios to your configured location.  I'll need to send them to you under separate cover because they have KDMAs unredacted so cannot be posted publicly.

I would change ITMSession's `self.ta1_integration` to True, then run the various TA1 session types:
- `python itm_minimal_runner.py --name foobar --session adept`
- `python itm_minimal_runner.py --name foobar --session adept --training`
- `python itm_minimal_runner.py --name foobar --session soartech`
- `python itm_minimal_runner.py --name foobar --session soartech --training`

You'll see server errors (especially for SoarTech scenarios) and not all SoarTech scenarios return session alignment.  All of the ADEPT ones should, although they're still updating `DryRunEval-MJ5-eval`.

See [client PR](https://github.com/NextCenturyCorporation/itm-evaluation-client/pull/53)