### PR TITLE
ITM-526:  Add action pre-validation step 

### DIFF
--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -533,6 +533,53 @@ class ITMSession:
         return self.take_or_intend_action(body, True)
 
 
+    def prevalidate_action(self, adm_action: Action) -> str:
+        """
+        Ensure that an ADM's version of a given action (by action_id) matches the scene's.
+
+        Args:
+            adm_action: the Action that the ADM sent
+
+        Returns:
+            Either an error string, or None if prevalidation passes
+        """
+        scene_mapping = None
+        for mapping in self.itm_scenario.isd.current_scene.action_mappings:
+            if mapping.action_id == adm_action.action_id:
+                scene_mapping = mapping
+                break
+
+        # If the ADM action is not from an action_mapping, then pre-validation doesn't apply and there's no error.
+        if not scene_mapping:
+            return None
+
+        # If we found the action in the action mappings, validate the adm action against it
+        scene_action = Action(action_id=scene_mapping.action_id,
+                              action_type=scene_mapping.action_type,
+                              intent_action=scene_mapping.intent_action,
+                              character_id=scene_mapping.character_id,
+                              parameters=scene_mapping.parameters
+                              )
+
+        if adm_action.action_type != scene_action.action_type:
+            return f"ADM action_type ({adm_action.action_type}) doesn't match scene ({scene_action.action_type}) for action_id '{adm_action.action_id}'."
+        if adm_action.intent_action != scene_action.intent_action:
+            return f"ADM intent_action ({adm_action.intent_action}) doesn't match scene ({scene_action.intent_action}) for action_id '{adm_action.action_id}'."
+        if scene_action.character_id and adm_action.character_id != scene_action.character_id:
+            return f"ADM character_id ({adm_action.character_id}) doesn't match scene ({scene_action.character_id}) for action_id '{adm_action.action_id}'."
+        if scene_action.parameters:
+            for key in scene_action.parameters.keys():
+                if not adm_action.parameters:
+                    return f"Action parameter '{key}' missing from ADM action for action_id '{adm_action.action_id}'."
+                scene_value = scene_action.parameters.get(key)
+                adm_value = adm_action.parameters.get(key)
+                if scene_value and adm_value != scene_value:
+                    return f"ADM value for parameter '{key}' doesn't match scene for action_id '{adm_action.action_id}': ({adm_value} != {scene_value})."
+
+        # Everything passes
+        return None
+
+
     def take_or_intend_action(self, adm_action: Action, intent_only) -> State:
         """
         Take or intend an action within a scenario
@@ -552,6 +599,11 @@ class ITMSession:
         elif adm_action.parameters:
             message += f" with parameters {adm_action.parameters}"
         logging.info(message + '.')
+
+        # Pre-validate action.  This ensures the ADM didn't change a pre-configured action in ways it shouldn't
+        prevalidation_error = self.prevalidate_action(adm_action)
+        if prevalidation_error:
+            return prevalidation_error, 400
 
         # Validate the right type of action (taken or intended)
         if intent_only and not adm_action.intent_action:


### PR DESCRIPTION
This happens before action validation, and is to ensure ADM didn't change a pre-configured action in ways it shouldn't.  Right now, the server is very trusting...

To test, what I did was to modify the `itm_minimal_runner.py` client to hack up the action it sends.  After `action = get_next_action()`, add something like:
```
if random.randint(0, 5) == 3:
      action.action_type = "DIRECT_MOBILE_CHARACTERS"
```

Then run, say, an adept session like `python itm_minimal_runner.py --session adept --name foobar`.
Eventually, you should get an error about the `action_type` being wrong.
Try replacing the second line above with other hacks (one at a time) to get different error messages:
- `action.character_id = 'foobar'`
- `action.intent_action = True`
- `action.parameters = {"foobar": "asdf"}`
- `action.parameters = None`

Sometimes you may have to try a few times to get the error message you want.