### PR TITLE
ITM-586: Final DRE enhancements to scenario runner/config

### DIFF
--- a/swagger_server/config.ini.template
+++ b/swagger_server/config.ini.template
@@ -10,16 +10,18 @@ SCENARIO_DIRECTORY=swagger_server/itm/data/%(EVALUATION_TYPE)s/scenarios/
 ; ADEPT_URL=http://localhost:8081
 ; SOARTECH_URL=http://localhost:8084
 
-; AWS TA1 Default URLs
+; AWS TA1 Default URLs (access Prod AWS servers locally)
 ; ADEPT_URL=https://darpaitm.caci.com/adept
 ; SOARTECH_URL=https://darpaitm.caci.com/soartech
 
-; Prod Default URLs
+; Prod Default URLs (use on production AWS only)
 SOARTECH_URL=http://10.216.38.125:8084
 ADEPT_URL=http://10.216.38.101:8080
 
 SAVE_HISTORY=True
 SAVE_HISTORY_TO_S3=True
+; This applies to `soartech` and `adept` non-training sessions
+ALWAYS_CONNECT_TO_TA1=True
 
 HISTORY_DIRECTORY=itm_history_output
 HISTORY_S3_BUCKET=itm-ui-assets
@@ -76,3 +78,43 @@ SOARTECH_VOL_ALIGNMENT_TARGETS=vol-human-8022671-SplitHighMulti,
     vol-synth-HighCluster,
     vol-synth-LowCluster,
     vol-synth-SplitLowBinary
+
+ADEPT_EVAL_FILENAMES=dryrun-adept-eval-MJ2.yaml,
+    dryrun-adept-eval-MJ4.yaml,
+    dryrun-adept-eval-MJ5.yaml
+
+ADEPT_TRAIN_FILENAMES=dryrun-adept-train-MJ1.yaml,
+    dryrun-adept-train-MJ3.yaml,
+    dryrun-adept-train-IO1.yaml,
+    dryrun-adept-train-IO2.yaml,
+    dryrun-adept-train-IO3.yaml
+
+ADEPT_EVAL_MJ_SCENARIOS=DryRunEval-MJ2-eval,DryRunEval-MJ4-eval,DryRunEval-MJ5-eval
+ADEPT_EVAL_IO_SCENARIOS=DryRunEval-MJ2-eval,DryRunEval-MJ4-eval,DryRunEval-MJ5-eval
+
+ADEPT_TRAIN_MJ_SCENARIOS=DryRunEval.MJ1,DryRunEval.MJ3
+ADEPT_TRAIN_IO_SCENARIOS=DryRunEval.IO1,DryRunEval.IO2,DryRunEval.IO3
+
+ADEPT_MJ_ALIGNMENT_TARGETS=ADEPT-DryRun-Moral judgement-0.0,
+    ADEPT-DryRun-Moral judgement-0.1,
+    ADEPT-DryRun-Moral judgement-0.2,
+    ADEPT-DryRun-Moral judgement-0.3,
+    ADEPT-DryRun-Moral judgement-0.4,
+    ADEPT-DryRun-Moral judgement-0.5,
+    ADEPT-DryRun-Moral judgement-0.6,
+    ADEPT-DryRun-Moral judgement-0.7,
+    ADEPT-DryRun-Moral judgement-0.8,
+    ADEPT-DryRun-Moral judgement-0.9,
+    ADEPT-DryRun-Moral judgement-1.0
+
+ADEPT_IO_ALIGNMENT_TARGETS=ADEPT-DryRun-Ingroup Bias-0.0,
+    ADEPT-DryRun-Ingroup Bias-0.1,
+    ADEPT-DryRun-Ingroup Bias-0.2,
+    ADEPT-DryRun-Ingroup Bias-0.3,
+    ADEPT-DryRun-Ingroup Bias-0.4,
+    ADEPT-DryRun-Ingroup Bias-0.5,
+    ADEPT-DryRun-Ingroup Bias-0.6,
+    ADEPT-DryRun-Ingroup Bias-0.7,
+    ADEPT-DryRun-Ingroup Bias-0.8,
+    ADEPT-DryRun-Ingroup Bias-0.9,
+    ADEPT-DryRun-Ingroup Bias-1.0

--- a/swagger_server/config_util.py
+++ b/swagger_server/config_util.py
@@ -12,7 +12,7 @@ class config_data:
 
 def read_ini(default_path='swagger_server/config.ini'):
     path = os.path.expanduser(default_path)
-    parser = ConfigParser()
+    parser = ConfigParser(os.environ)
     parser.read(path)
     return (parser, path)
 
@@ -22,9 +22,11 @@ def check_ini():
     ini = parser_path[0]
     final_path = parser_path[1]
     if exists(final_path):
-        keys = ("EVALUATION_TYPE", "SCENARIO_DIRECTORY", "ADEPT_URL", "SOARTECH_URL", "SAVE_HISTORY", "SAVE_HISTORY_TO_S3", "HISTORY_DIRECTORY", "HISTORY_S3_BUCKET",
+        keys = ("EVALUATION_TYPE", "SCENARIO_DIRECTORY", "ADEPT_URL", "SOARTECH_URL", "SAVE_HISTORY", "SAVE_HISTORY_TO_S3", "ALWAYS_CONNECT_TO_TA1", "HISTORY_DIRECTORY", "HISTORY_S3_BUCKET",
                 "EVAL_NAME", "EVAL_NUMBER", "SOARTECH_EVAL_QOL_SCENARIOS", "SOARTECH_EVAL_VOL_SCENARIOS", "SOARTECH_TRAIN_QOL_SCENARIOS", "SOARTECH_TRAIN_VOL_SCENARIOS",
-                "SOARTECH_QOL_ALIGNMENT_TARGETS", "SOARTECH_VOL_ALIGNMENT_TARGETS", "SOARTECH_EVAL_FILENAMES", "SOARTECH_TRAIN_FILENAMES")
+                "SOARTECH_QOL_ALIGNMENT_TARGETS", "SOARTECH_VOL_ALIGNMENT_TARGETS", "SOARTECH_EVAL_FILENAMES", "SOARTECH_TRAIN_FILENAMES",
+                "ADEPT_EVAL_MJ_SCENARIOS", "ADEPT_EVAL_IO_SCENARIOS", "ADEPT_TRAIN_MJ_SCENARIOS", "ADEPT_TRAIN_IO_SCENARIOS",
+                "ADEPT_MJ_ALIGNMENT_TARGETS", "ADEPT_IO_ALIGNMENT_TARGETS", "ADEPT_EVAL_FILENAMES", "ADEPT_TRAIN_FILENAMES")
         for option in keys:
             if option in ini["DEFAULT"]: # checks if "option" key exists in "default" section
                 key_value = ini.get("DEFAULT", option)

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -505,147 +505,51 @@ class ITMSession:
 
             alignment_targets = [target for target in ITMSession.alignment_data[ta1_name]]
             ta1_scenarios = []
+            scenario_ctr = 0
             for scenario in scenarios:
                 itm_scenario = \
                     ITMScenario(yaml_path=f'{path}{scenario}',
                                 session=self, training=self.kdma_training)
                 itm_scenario.generate_scenario_data()
-                ta1_scenarios.append(itm_scenario)
 
-                if ta1_name == "soartech":
-                    if itm_scenario.id in (ITMSession.SOARTECH_TRAIN_QOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_QOL_SCENARIOS):
-                        for counter in range(1, len(ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS)):
-                            ta1_scenarios.append(deepcopy(itm_scenario))
-                    if itm_scenario.id in (ITMSession.SOARTECH_TRAIN_VOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_VOL_SCENARIOS):
-                        for counter in range(1, len(ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS)):
-                            ta1_scenarios.append(deepcopy(itm_scenario))
-                elif ta1_name == "adept":
-                    if itm_scenario.id in (ITMSession.ADEPT_TRAIN_MJ_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_MJ_SCENARIOS):
-                        for counter in range(1, len(ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS)):
-                            ta1_scenarios.append(deepcopy(itm_scenario))
-                    if itm_scenario.id in (ITMSession.ADEPT_TRAIN_IO_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_IO_SCENARIOS):
-                        for counter in range(1, len(ITMSession.ADEPT_IO_ALIGNMENT_TARGETS)):
-                            ta1_scenarios.append(deepcopy(itm_scenario))
-                else: # "test" sessions
-                    for counter in range(1, len(alignment_targets)):
-                        ta1_scenarios.append(deepcopy(itm_scenario))
-
-            # if an integrated session, add ta1_controllers to each scenario
-            # else, add alignment_targets to each scenario
-            if self.ta1_integration:
-                controllers = ITMSession.ta1_controllers[ta1_name]
-                if ta1_name == "soartech":
-                    qol_counter = 0
-                    vol_counter = 0
-                    for scenario_ctr in range(len(ta1_scenarios)):
-                        #TODO: Refactor this block
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.SOARTECH_TRAIN_QOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_QOL_SCENARIOS):
-                            if alignment_targets[qol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[qol_counter % (len(alignment_targets))].id), None)))
-                                qol_counter = qol_counter + 1
-                            else:
-                                while alignment_targets[qol_counter % (len(alignment_targets))].id not in ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS:
-                                    qol_counter = qol_counter + 1
-                                if alignment_targets[qol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[qol_counter % (len(alignment_targets))].id), None)))
-                                    qol_counter = qol_counter + 1
-
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.SOARTECH_TRAIN_VOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_VOL_SCENARIOS):
-                            if alignment_targets[vol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[vol_counter % (len(alignment_targets))].id), None)))
-                                vol_counter = vol_counter + 1
-                            else:
-                                while alignment_targets[vol_counter % (len(alignment_targets))].id not in ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS:
-                                    vol_counter = vol_counter + 1
-                                if alignment_targets[vol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[vol_counter % (len(alignment_targets))].id), None)))
-                                    vol_counter = vol_counter + 1
+                if ta1_name == "test":
+                    ta1_scenarios.append(deepcopy(itm_scenario))
+                    ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[scenario_ctr % (len(alignment_targets))]
+                    scenario_ctr += 1
                 else:
-                    mj_counter = 0
-                    io_counter = 0
-                    for scenario_ctr in range(len(ta1_scenarios)):
-                        #TODO: Refactor this block
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.ADEPT_TRAIN_MJ_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_MJ_SCENARIOS):
-                            if alignment_targets[mj_counter % (len(alignment_targets))].id in ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[mj_counter % (len(alignment_targets))].id), None)))
-                                mj_counter = mj_counter + 1
-                            else:
-                                while alignment_targets[mj_counter % (len(alignment_targets))].id not in ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS:
-                                    mj_counter = mj_counter + 1
-                                if alignment_targets[mj_counter % (len(alignment_targets))].id in ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[mj_counter % (len(alignment_targets))].id), None)))
-                                    mj_counter = mj_counter + 1
+                    controllers = ITMSession.ta1_controllers[ta1_name] if self.ta1_integration else None
 
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.ADEPT_TRAIN_IO_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_IO_SCENARIOS):
-                            if alignment_targets[io_counter % (len(alignment_targets))].id in ITMSession.ADEPT_IO_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[io_counter % (len(alignment_targets))].id), None)))
-                                io_counter = io_counter + 1
+                    def __load_scenarios(alignment_targets, scenario_ctr):
+                        for target_id in alignment_targets:
+                            ta1_scenarios.append(deepcopy(itm_scenario))
+                            if self.ta1_integration:
+                                ta1_controller = deepcopy(next(controller for controller in controllers if controller.alignment_target_id == target_id), None)
+                                ta1_scenarios[scenario_ctr].set_controller(ta1_controller)
                             else:
-                                while alignment_targets[io_counter % (len(alignment_targets))].id not in ITMSession.ADEPT_IO_ALIGNMENT_TARGETS:
-                                    io_counter = io_counter + 1
-                                if alignment_targets[io_counter % (len(alignment_targets))].id in ITMSession.ADEPT_IO_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].set_controller(deepcopy(next((target for target in controllers if target.alignment_target_id  == alignment_targets[io_counter % (len(alignment_targets))].id), None)))
-                                    io_counter = io_counter + 1
-            else:
-                if ta1_name == "soartech":
-                    qol_counter = 0
-                    vol_counter = 0
-                    for scenario_ctr in range(len(ta1_scenarios)):
-                        #TODO: Refactor this block
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.SOARTECH_TRAIN_QOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_QOL_SCENARIOS):
-                            if alignment_targets[qol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[qol_counter % (len(alignment_targets))] 
-                                qol_counter = qol_counter + 1
-                            else:
-                                while alignment_targets[qol_counter % (len(alignment_targets))].id not in ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS:
-                                    qol_counter = qol_counter + 1
-                                if alignment_targets[qol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[qol_counter % (len(alignment_targets))] 
-                                    qol_counter = qol_counter + 1
+                                ta1_scenarios[scenario_ctr].alignment_target = next(target for target in alignment_targets if target.id == target_id), None
+                            scenario_ctr += 1
+                        return scenario_ctr
 
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.SOARTECH_TRAIN_VOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_VOL_SCENARIOS):
-                            if alignment_targets[vol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[vol_counter % (len(alignment_targets))]
-                                vol_counter = vol_counter + 1
-                            else:
-                                while alignment_targets[vol_counter % (len(alignment_targets))].id not in ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS:
-                                    vol_counter = vol_counter + 1
-                                if alignment_targets[vol_counter % (len(alignment_targets))].id in ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[vol_counter % (len(alignment_targets))]
-                                    vol_counter = vol_counter + 1
-                elif ta1_name == "adept":
-                    mj_counter = 0
-                    io_counter = 0
-                    for scenario_ctr in range(len(ta1_scenarios)):
-                        #TODO: Refactor this block
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.ADEPT_TRAIN_MJ_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_MJ_SCENARIOS):
-                            if alignment_targets[mj_counter % (len(alignment_targets))].id in ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[mj_counter % (len(alignment_targets))]
-                                mj_counter = mj_counter + 1
-                            else:
-                                while alignment_targets[mj_counter % (len(alignment_targets))].id not in ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS:
-                                    mj_counter = mj_counter + 1
-                                if alignment_targets[mj_counter % (len(alignment_targets))].id in ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[mj_counter % (len(alignment_targets))] 
-                                    mj_counter = mj_counter + 1
-
-                        if ta1_scenarios[scenario_ctr].id in (ITMSession.ADEPT_TRAIN_IO_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_IO_SCENARIOS):
-                            if alignment_targets[io_counter % (len(alignment_targets))].id in ITMSession.ADEPT_IO_ALIGNMENT_TARGETS:
-                                ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[io_counter % (len(alignment_targets))]
-                                io_counter = io_counter + 1
-                            else:
-                                while alignment_targets[io_counter % (len(alignment_targets))].id not in ITMSession.ADEPT_IO_ALIGNMENT_TARGETS:
-                                    io_counter = io_counter + 1
-                                if alignment_targets[io_counter % (len(alignment_targets))].id in ITMSession.ADEPT_IO_ALIGNMENT_TARGETS:
-                                    ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[io_counter % (len(alignment_targets))]
-                                    io_counter = io_counter + 1
-                else: # "test" sessions
-                    for scenario_ctr in range(len(ta1_scenarios)):
-                        ta1_scenarios[scenario_ctr].alignment_target = alignment_targets[scenario_ctr % (len(alignment_targets))]
+                    if ta1_name == "soartech":
+                        if itm_scenario.id in (ITMSession.SOARTECH_TRAIN_QOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_QOL_SCENARIOS):
+                            scenario_ctr = __load_scenarios(ITMSession.SOARTECH_QOL_ALIGNMENT_TARGETS, scenario_ctr)
+                        if itm_scenario.id in (ITMSession.SOARTECH_TRAIN_VOL_SCENARIOS if kdma_training else ITMSession.SOARTECH_EVAL_VOL_SCENARIOS):
+                            scenario_ctr = __load_scenarios(ITMSession.SOARTECH_VOL_ALIGNMENT_TARGETS, scenario_ctr)
+                    elif ta1_name == "adept":
+                        if itm_scenario.id in (ITMSession.ADEPT_TRAIN_MJ_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_MJ_SCENARIOS):
+                            scenario_ctr = __load_scenarios(ITMSession.ADEPT_MJ_ALIGNMENT_TARGETS, scenario_ctr)
+                        if itm_scenario.id in (ITMSession.ADEPT_TRAIN_IO_SCENARIOS if kdma_training else ITMSession.ADEPT_EVAL_IO_SCENARIOS):
+                            scenario_ctr = __load_scenarios(ITMSession.ADEPT_IO_ALIGNMENT_TARGETS, scenario_ctr)
 
             self.itm_scenarios.extend(ta1_scenarios)
             num_read_scenarios += len(ta1_scenarios)
             logging.info('Loaded %d scenarios for %s.', len(ta1_scenarios), ta1_name)
+
+        scenario_ctr = 0
+        logging.info("Scenario load summary:")
+        for scenario in self.itm_scenarios:
+            logging.info(f'  Scenario #{scenario_ctr} has ID {scenario.id} and alignment target {scenario.alignment_target.id}.')
+            scenario_ctr += 1
 
         if max_scenarios is not None and max_scenarios >= num_read_scenarios:
             self.using_max_scenarios = True

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -133,7 +133,7 @@ class ITMSession:
         for ta1_name in ta1_names:
             ITMSession.alignment_data[ta1_name] = [
                 alignment_target for alignment_target in ITMTa1Controller.get_alignment_data(ta1_name)
-                    if 'train' not in alignment_target.id
+                    if 'train' not in alignment_target.id or ta1_name == 'soartech'
             ]
             ITMSession.ta1_controllers[ta1_name] = [
                 ITMTa1Controller(alignment_target_id=alignment_target.id,


### PR DESCRIPTION
Work performed:
- Added ADEPT to the current scenario runner configuration.
- Refactored or replaced indicated areas (TODO) in `start_session`;
- Added `ALWAYS_CONNECT_TO_TA1` (for non-training, non-eval sessions) to configuration; and
- Allowed config vars to have embedded environment variables (Parallax request).

To test:
- First, update your `config.ini` with the new stuff added to the template.
- Run all session types (while connected to TA1 servers):  `eval`, `soartech`, `adept`, and `test`.
- Refer to new logging to see which scenarios/alignment targets are configured to run.
- Update your `config.ini` to remove a subset of ST and ADEPT scenarios/alignment targets, and try again.
- Make sure that your config file is internally consistent (e.g., `ADEPT_EVAL_FILENAMES` is in consistent with `ADEPT_EVAL_MJ_SCENARIOS`).
- Run a training scenarios (`--training`) for both ST and ADEPT.
- Use an environment variable somewhere in config, e.g., `ADEPT_URL=http://localhost:%(ADEPT_PORT)s` 

**NOTE**: Currently, standalone non-test sessions don't work (e.g., `--soartech` and `--adept`, when `ALWAYS_CONNECT_TO_TA1` is False).  This will be addressed in the next ticket, `ITM-563`.

IMO, you don't need to have all of these tests run to completion.  Certainly a full `eval` session should be fully tested.  If you want to short-circuit the server so that it shows you what it's going to run without actually running it, add `raise Exception("Done!")` right before `start_session()` returns (should be at `itm_session.py` line 563).