### PR TITLE
ITM-672:  Add solo (standalone) training mode

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -49,13 +49,12 @@ paths:
             example: eval
         - name: kdma_training
           in: query
-          description: whether or not this is a training session with TA2
+          description: "whether this is a `full`, `solo`, or non-training session with TA2"
           required: false
           style: form
           explode: true
           schema:
-            type: boolean
-            default: false
+            type: string
         - name: max_scenarios
           in: query
           description:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -976,7 +976,9 @@ components:
         triss:
           type: number
           format: float
-          description: Trauma Score and Injury Severity Score
+          description: >
+            Trauma and Injury Severity Score, a calculation that combines patient vitals and injury severity to predict
+            a patient's probability of survival
           minimum: 0.0
           maximum: 100.0
         spo2:

--- a/swagger_server/controllers/itm_ta2_eval_controller.py
+++ b/swagger_server/controllers/itm_ta2_eval_controller.py
@@ -109,7 +109,7 @@ def _reclaim_old_session():
             return ITMSession()
     return None
 
-def start_session(adm_name, session_type, adm_profile=None, kdma_training=False, max_scenarios=None):  # noqa: E501
+def start_session(adm_name, session_type, adm_profile=None, kdma_training=None, max_scenarios=None):  # noqa: E501
     """Start a new session
 
     Get unique session id for grouping answers from a collection of scenarios/probes together # noqa: E501
@@ -120,8 +120,8 @@ def start_session(adm_name, session_type, adm_profile=None, kdma_training=False,
     :type session_type: str
     :param adm_profile: a profile of the ADM in terms of its alignment strategy
     :type adm_profile: str
-    :param kdma_training: whether or not this is a training session with TA2
-    :type kdma_training: bool
+    :param kdma_training: whether this is a `full`, `solo`, or non-training session with TA2
+    :type kdma_training: str
     :param max_scenarios: the maximum number of scenarios requested, supported only in `test` sessions
     :type max_scenarios: int
 
@@ -152,7 +152,7 @@ def start_session(adm_name, session_type, adm_profile=None, kdma_training=False,
         adm_name=adm_name,
         session_type=session_type,
         adm_profile=adm_profile if adm_profile != 'None' else None,
-        kdma_training=kdma_training,
+        kdma_training=kdma_training if kdma_training != 'None' else None,
         adept_populations=True,
         max_scenarios=max_scenarios
     )

--- a/swagger_server/models/vitals.py
+++ b/swagger_server/models/vitals.py
@@ -186,7 +186,7 @@ class Vitals(Model):
     def triss(self) -> float:
         """Gets the triss of this Vitals.
 
-        Trauma Score and Injury Severity Score  # noqa: E501
+        Trauma and Injury Severity Score, a calculation that combines patient vitals and injury severity to predict a patient's probability of survival   # noqa: E501
 
         :return: The triss of this Vitals.
         :rtype: float
@@ -197,7 +197,7 @@ class Vitals(Model):
     def triss(self, triss: float):
         """Sets the triss of this Vitals.
 
-        Trauma Score and Injury Severity Score  # noqa: E501
+        Trauma and Injury Severity Score, a calculation that combines patient vitals and injury severity to predict a patient's probability of survival   # noqa: E501
 
         :param triss: The triss of this Vitals.
         :type triss: float


### PR DESCRIPTION
Added solo (standalone) training mode that returns kdmas but doesn't request session alignment.
Test with client [ITM-672 branch](https://github.com/NextCenturyCorporation/itm-evaluation-client/tree/ITM-672).

For testing instructions, see the [client PR](https://github.com/NextCenturyCorporation/itm-evaluation-client/pull/64).

Note line 219 of `itm_session.py`.  It's a temporary line for testing this PR so that you don't have to see a dump of complete session history.  Please remind me to remove it prior to merging.  :)