### PR TITLE
ITM-638: More sync with Sim re: treatments/supplies

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,18 +119,19 @@ To run with TA1 on multiple systems set docker env vars for ADM host, Soartech H
 ```bash
 docker run -d -p 8080:8080 --name itm-server itm-server
 ```
-** Note, If setting TA3_PORT to anything other then the default requires the docker run command to expose those ports. 
-Can write the above command as $TA3_PORT:$TA3_PORT however, this will not work if it is not set and won't default.
+** Note, If setting `TA3_PORT` to anything other then the default requires the docker run command to expose those ports. 
+Can write the above command as `$TA3_PORT:$TA3_PORT` however, this will not work if it is not set and won't default.
 
 ## Manual runs on separate instances
 If running the command instead of docker set the environment variables for:
-- TA3_PORT (default:8080)
+- `TA3_PORT` (default:8080)
 
 ## Updating models
 This requires JDK 8 or higher to run the gradle tool.
 
-The models in swagger_server/models are generated from the following files
-    swagger_server/swagger/swagger.yaml
-    swagger_server/swagger/ta1.yaml
+The models in swagger_server/models are generated from the following files:
+* `swagger_server/swagger/swagger.yaml`
+* `swagger_server/swagger/ta1.yaml`
+
 If these files are updated they will need to be re-generated and checked in.
 Run `./gradlew` to do this.

--- a/swagger_server/itm/data/dryrun/test/removed_characters.yaml
+++ b/swagger_server/itm/data/dryrun/test/removed_characters.yaml
@@ -139,14 +139,6 @@ scenes:
         character_id: Mike
         probe_id: test-probe-1
         choice: test-choice2
-      - action_id: action3
-        action_type: APPLY_TREATMENT
-        unstructured: Treat Mike's injury
-        character_id: Mike
-        # Here, the probe response is only sent if the specified treatment is made to the specified location
-        parameters: { "treatment": "Tourniquet", "location": "right forearm" }
-        probe_id: test-probe-1
-        choice: test-choice3
       - action_id: action4
         action_type: SITREP
         unstructured: Ask Civilian to provide SITREP

--- a/swagger_server/itm/data/phase1/test/downstream_injuries.yaml
+++ b/swagger_server/itm/data/phase1/test/downstream_injuries.yaml
@@ -1,0 +1,314 @@
+id: downstream_injuries
+name: Automatic treatment of downstream injuries
+# Test description: Tourniquet treatments on an upper arm/leg also treat downstream injuries that require a tourniquet.
+state:
+  unstructured: Testing downstream injuries.  Certain successful tourniquet treatments also treat downstream injuries.
+  mission:
+    unstructured: No mission parameters
+    mission_type: Patrol
+
+  environment:
+    sim_environment:
+      type: jungle
+    decision_environment:
+      unstructured: >
+        Testing downstream injuries.  Treating the left upstream injuries (bicep/thigh) should treat the downstream injuries
+        (forearm/wrist/calf).  Treating the right upstream injuries should NOT treat the downstream injuries.
+  supplies:
+    - { type: Tourniquet, quantity: 50 }
+  characters:
+    - id: Mike
+      name: Mike
+      unstructured: Patient with multiple injuries that require a tourniquet.
+      demographics:
+        age: 34
+        sex: M
+        race: White
+      vitals:
+        avpu: ALERT
+        ambulatory: true
+        mental_status: CALM
+        breathing: NORMAL
+        heart_rate: NORMAL
+        spo2: NORMAL
+      injuries:
+        - name: Puncture # Treating this should treat left forearm
+          location: left bicep
+          status: visible
+        - name: Puncture
+          location: left forearm
+          status: visible
+        - name: Puncture  # Treating this should NOT treat left forearm
+          location: right bicep
+          status: visible
+        - name: Puncture # Treating this should treat left calf
+          location: left thigh
+          status: visible
+        - name: Puncture
+          location: left calf
+          status: visible
+        - name: Puncture # Treating this should NOT treat left calf
+          location: right thigh
+          status: visible
+scenes:
+  - id: fix_mike
+    next_scene: fix_travis
+    end_scene_allowed: false
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-mike-left-bicep
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's left bicep (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Tourniquet", "location": "left bicep" }
+        probe_id: test-1
+        choice: test-mike-left-bicep
+      - action_id: treat-mike-right-bicep
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's right bicep (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Tourniquet", "location": "right bicep" }
+        probe_id: test-1
+        choice: test-mike-right-bicep
+      - action_id: treat-mike-left-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's left thigh (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Tourniquet", "location": "left thigh" }
+        probe_id: test-1
+        choice: test-mike-left-thigh
+      - action_id: treat-mike-right-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's right thigh (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Tourniquet", "location": "right thigh" }
+        probe_id: test-1
+        choice: test-mike-right-thigh
+    transitions:
+      actions:
+        - [treat-mike-left-bicep, treat-mike-left-thigh] # actions within a list have "and" semantics
+
+  - id: fix_travis
+    next_scene: fix_andrew
+    end_scene_allowed: false
+    state:
+      unstructured: Testing multiple injuries at one location.
+      characters:
+      - id: Travis
+        name: Travis
+        unstructured: Patient with multiple injuries that require a tourniquet.
+        demographics:
+          age: 34
+          sex: M
+          race: White
+        vitals:
+          avpu: ALERT
+          ambulatory: true
+          mental_status: CALM
+          breathing: NORMAL
+          heart_rate: NORMAL
+          spo2: NORMAL
+        injuries:
+          - name: Puncture # Treating this should treat left wrist
+            location: left bicep
+            status: visible
+          - name: Amputation
+            location: left wrist
+            status: visible
+          - name: Puncture  # Treating this should NOT treat left wrist
+            location: right bicep
+            status: visible
+          - name: Puncture # Treating this should treat left calf
+            location: left thigh
+            status: visible
+          - name: Amputation
+            location: left calf
+            status: visible
+          - name: Puncture # Treating this should NOT treat left calf
+            location: right thigh
+            status: visible
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-travis-left-bicep
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's left bicep (puncture) injury
+        character_id: Travis
+        parameters: { "treatment": "Tourniquet", "location": "left bicep" }
+        probe_id: test-1
+        choice: test-travis-left-bicep
+      - action_id: treat-travis-right-bicep
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's right bicep (puncture) injury
+        character_id: Travis
+        parameters: { "treatment": "Tourniquet", "location": "right bicep" }
+        probe_id: test-1
+        choice: test-travis-right-bicep
+      - action_id: treat-travis-left-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's left thigh (puncture) injury
+        character_id: Travis
+        parameters: { "treatment": "Tourniquet", "location": "left thigh" }
+        probe_id: test-1
+        choice: test-travis-left-thigh
+      - action_id: treat-travis-right-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's right thigh (puncture) injury
+        character_id: Travis
+        parameters: { "treatment": "Tourniquet", "location": "right thigh" }
+        probe_id: test-1
+        choice: test-travis-right-thigh
+    transitions:
+      actions:
+        - [treat-travis-left-bicep, treat-travis-left-thigh] # actions within a list have "and" semantics
+
+  - id: fix_andrew
+    next_scene: fix_adam
+    end_scene_allowed: false
+    state:
+      unstructured: Testing multiple injuries at one location.
+      characters:
+      - id: Andrew
+        name: Andrew
+        unstructured: Patient with multiple injuries that require a tourniquet.
+        demographics:
+          age: 34
+          sex: M
+          race: White
+        vitals:
+          avpu: ALERT
+          ambulatory: true
+          mental_status: CALM
+          breathing: NORMAL
+          heart_rate: NORMAL
+          spo2: NORMAL
+        injuries:
+          - name: Puncture # Treating this should treat left wrist
+            location: left forearm
+            status: visible
+          - name: Amputation
+            location: left wrist
+            status: visible
+          - name: Puncture  # Treating this should NOT treat left wrist
+            location: right forearm
+            status: visible
+          - name: Laceration # Treating this should treat left calf
+            location: left thigh
+            status: visible
+          - name: Puncture
+            location: left calf
+            status: visible
+          - name: Laceration # Treating this should NOT treat left calf
+            location: right thigh
+            status: visible
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-andrew-left-forearm
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's left forearm (puncture) injury
+        character_id: Andrew
+        parameters: { "treatment": "Tourniquet", "location": "left forearm" }
+        probe_id: test-1
+        choice: test-andrew-left-forearm
+      - action_id: treat-andrew-right-forearm
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's right forearm (puncture) injury
+        character_id: Andrew
+        parameters: { "treatment": "Tourniquet", "location": "right forearm" }
+        probe_id: test-1
+        choice: test-andrew-right-forearm
+      - action_id: treat-andrew-left-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's left thigh (laceration) injury
+        character_id: Andrew
+        parameters: { "treatment": "Tourniquet", "location": "left thigh" }
+        probe_id: test-1
+        choice: test-andrew-left-thigh
+      - action_id: treat-andrew-right-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's right thigh (laceration) injury
+        character_id: Andrew
+        parameters: { "treatment": "Tourniquet", "location": "right thigh" }
+        probe_id: test-1
+        choice: test-andrew-right-thigh
+    transitions:
+      actions:
+        - [treat-andrew-left-forearm, treat-andrew-left-thigh] # actions within a list have "and" semantics
+
+  - id: fix_adam
+    end_scene_allowed: false
+    state:
+      unstructured: Testing multiple injuries at one location.
+      characters:
+      - id: Adam
+        name: Adam
+        unstructured: >
+          Patient with multiple injuries that require a tourniquet,
+          plus injuries where unsuccessful hemostatic gauze treatments will consume the supply.
+        demographics:
+          age: 34
+          sex: M
+          race: White
+        vitals:
+          avpu: ALERT
+          ambulatory: true
+          mental_status: CALM
+          breathing: NORMAL
+          heart_rate: NORMAL
+          spo2: NORMAL
+        injuries:
+          - name: Laceration # Treating this should treat left calf
+            location: left thigh
+            status: visible
+          - name: Amputation
+            location: left calf
+            status: visible
+          - name: Laceration # Treating this should NOT treat left calf
+            location: right thigh
+            status: visible
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-adam-left-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Adam's left thigh (laceration) injury
+        character_id: Adam
+        parameters: { "treatment": "Tourniquet", "location": "left thigh" }
+        probe_id: test-1
+        choice: test-adam-left-thigh
+      - action_id: treat-adam-right-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Adam's right thigh (laceration) injury
+        character_id: Adam
+        parameters: { "treatment": "Tourniquet", "location": "right thigh" }
+        probe_id: test-1
+        choice: test-adam-right-thigh
+    transitions:
+      actions:
+        - [treat-adam-left-thigh, treat-adam-right-thigh] # actions within a list have "and" semantics

--- a/swagger_server/itm/data/phase1/test/removed_characters.yaml
+++ b/swagger_server/itm/data/phase1/test/removed_characters.yaml
@@ -139,14 +139,6 @@ scenes:
         character_id: Mike
         probe_id: test-probe-1
         choice: test-choice2
-      - action_id: action3
-        action_type: APPLY_TREATMENT
-        unstructured: Treat Mike's injury
-        character_id: Mike
-        # Here, the probe response is only sent if the specified treatment is made to the specified location
-        parameters: { "treatment": "Tourniquet", "location": "right forearm" }
-        probe_id: test-probe-1
-        choice: test-choice3
       - action_id: action4
         action_type: SITREP
         unstructured: Ask Civilian to provide SITREP

--- a/swagger_server/itm/data/phase1/test/supply_consumption.yaml
+++ b/swagger_server/itm/data/phase1/test/supply_consumption.yaml
@@ -1,0 +1,347 @@
+id: supply_consumption
+name: Supply consumption after unsuccessful treatments
+# Test description: Test consumption of supplies after certain unsuccessful treatments.
+state:
+  unstructured: Testing consumption of certain supplies after unsuccessful treatments.
+  mission:
+    unstructured: No mission parameters
+    mission_type: Patrol
+
+  environment:
+    sim_environment:
+      type: jungle
+    decision_environment:
+      unstructured: >
+        Testing consumption of certain supplies after unsuccessful treatments.  Using hemostatic gauze on injuries injuries where
+        a tourniquet or pressure bandage is called for consumes the gauze.  Decompression needles can be placed anywhere in any quantity,
+        consuming supplies.  Using an airway (on right or left face) always consumes a supply, even if there's no injury.
+  supplies:
+    - { type: Nasopharyngeal airway, quantity: 50 }
+    - { type: Hemostatic gauze, quantity: 50 }
+    - { type: Decompression Needle, quantity: 50 }
+  characters:
+    - id: Mike
+      name: Mike
+      unstructured: Patient with multiple punctures that require a tourniquet, but treating with hemostatic gauze will consume the supply.
+      demographics:
+        age: 34
+        sex: M
+        race: White
+      vitals:
+        avpu: ALERT
+        ambulatory: true
+        mental_status: CALM
+        breathing: NORMAL
+        heart_rate: NORMAL
+        spo2: NORMAL
+      injuries:
+        - name: Puncture # (Mis)-treating this with hemostatic gauze should consume the supply
+          location: left bicep
+          status: visible
+        - name: Puncture # (Mis)-treating this with hemostatic gauze should consume the supply
+          location: right forearm
+          status: visible
+        - name: Puncture # (Mis)-treating this with hemostatic gauze should consume the supply
+          location: left thigh
+          status: visible
+        - name: Puncture # (Mis)-treating this with hemostatic gauze should consume the supply
+          location: right calf
+          status: visible
+scenes:
+  - id: fix_mike
+    next_scene: fix_travis
+    end_scene_allowed: false
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-mike-left-bicep
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's left bicep (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Hemostatic gauze", "location": "left bicep" }
+        probe_id: test-1
+        choice: test-mike-left-bicep
+      - action_id: treat-mike-right-forearm
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's right forearm (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Hemostatic gauze", "location": "right forearm" }
+        probe_id: test-1
+        choice: test-mike-right-forearm
+      - action_id: treat-mike-left-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's left thigh (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Hemostatic gauze", "location": "left thigh" }
+        probe_id: test-1
+        choice: test-mike-left-thigh
+      - action_id: treat-mike-right-calf
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Mike's right calf (puncture) injury
+        character_id: Mike
+        parameters: { "treatment": "Hemostatic gauze", "location": "right calf" }
+        probe_id: test-1
+        choice: test-mike-right-calf
+      - action_id: treat-mike-with-needle
+        action_type: APPLY_TREATMENT
+        repeatable: true
+        unstructured: Apply a decompression needle to Mike
+        character_id: Mike
+        parameters: { "treatment": "Decompression Needle" }
+        probe_id: test-1
+        choice: treat-mike-with-needle
+      - action_id: treat-mike-with-airway
+        action_type: APPLY_TREATMENT
+        repeatable: true
+        unstructured: Apply a Nasopharyngeal airway to Mike
+        character_id: Mike
+        parameters: { "treatment": "Nasopharyngeal airway" }
+        probe_id: test-1
+        choice: treat-mike-with-airway
+    transitions:
+      actions:
+        - [treat-mike-left-bicep, treat-mike-right-forearm, treat-mike-left-thigh, treat-mike-right-calf, treat-mike-with-needle, treat-mike-with-airway] # actions within a list have "and" semantics
+
+  - id: fix_travis
+    next_scene: fix_andrew
+    end_scene_allowed: false
+    state:
+      unstructured: Testing applying hemostatic gauze to lacerations where a pressure bandage is called for.
+      characters:
+      - id: Travis
+        name: Travis
+        unstructured: Patient with multiple lacerations that require a pressure bandage, but treating with hemostatic gauze will consume the supply.
+        demographics:
+          age: 34
+          sex: M
+          race: White
+        vitals:
+          avpu: ALERT
+          ambulatory: true
+          mental_status: CALM
+          breathing: NORMAL
+          heart_rate: NORMAL
+          spo2: NORMAL
+        injuries:
+          - name: Laceration # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: left face
+            status: visible
+          - name: Laceration # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: left forearm
+            status: visible
+          - name: Laceration # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: left stomach
+            status: visible
+          - name: Laceration # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: right hand
+            status: visible
+          - name: Laceration # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: right calf
+            status: visible
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-travis-left-face
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's left face (laceration) injury
+        character_id: Travis
+        parameters: { "treatment": "Hemostatic gauze", "location": "left face" }
+        probe_id: test-1
+        choice: test-travis-left-face
+      - action_id: treat-travis-left-forearm
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's left forearm (laceration) injury
+        character_id: Travis
+        parameters: { "treatment": "Hemostatic gauze", "location": "left forearm" }
+        probe_id: test-1
+        choice: test-travis-left-forearm
+      - action_id: treat-travis-left-stomach
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's left stomach (laceration) injury
+        character_id: Travis
+        parameters: { "treatment": "Hemostatic gauze", "location": "left stomach" }
+        probe_id: test-1
+        choice: test-travis-left-stomach
+      - action_id: treat-travis-right-hand
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's right hand (laceration) injury
+        character_id: Travis
+        parameters: { "treatment": "Hemostatic gauze", "location": "right hand" }
+        probe_id: test-1
+        choice: test-travis-right-hand
+      - action_id: treat-travis-right-calf
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Travis's right calf (laceration) injury
+        character_id: Travis
+        parameters: { "treatment": "Hemostatic gauze", "location": "right calf" }
+        probe_id: test-1
+        choice: test-travis-right-calf
+    transitions:
+      actions:
+        - [treat-travis-left-face, treat-travis-left-forearm, treat-travis-left-stomach, treat-travis-right-hand, treat-travis-right-calf] # actions within a list have "and" semantics
+
+  - id: fix_andrew
+    next_scene: fix_adam
+    end_scene_allowed: false
+    state:
+      unstructured: Testing applying hemostatic gauze to abrasions where a pressure bandage is called for.
+      characters:
+      - id: Andrew
+        name: Andrew
+        unstructured: Patient with multiple abrasions that require a pressure bandage, but treating with hemostatic gauze will consume the supply.
+        demographics:
+          age: 34
+          sex: M
+          race: White
+        vitals:
+          avpu: ALERT
+          ambulatory: true
+          mental_status: CALM
+          breathing: NORMAL
+          heart_rate: NORMAL
+          spo2: NORMAL
+        injuries:
+          - name: Abrasion # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: left face
+            status: visible
+          - name: Abrasion # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: right bicep
+            status: visible
+          - name: Abrasion # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: left forearm
+            status: visible
+          - name: Abrasion # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: right thigh
+            status: visible
+          - name: Abrasion # (Mis)-treating this with hemostatic gauze should consume the supply
+            location: left calf
+            status: visible
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-andrew-left-face
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's left face (abrasion) injury
+        character_id: Andrew
+        parameters: { "treatment": "Hemostatic gauze", "location": "left face" }
+        probe_id: test-1
+        choice: test-andrew-left-face
+      - action_id: treat-andrew-right-bicep
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's right bicep (abrasion) injury
+        character_id: Andrew
+        parameters: { "treatment": "Hemostatic gauze", "location": "right bicep" }
+        probe_id: test-1
+        choice: test-andrew-right-bicep
+      - action_id: treat-andrew-left-forearm
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's left forearm (abrasion) injury
+        character_id: Andrew
+        parameters: { "treatment": "Hemostatic gauze", "location": "left forearm" }
+        probe_id: test-1
+        choice: test-andrew-left-forearm
+      - action_id: treat-andrew-right-thigh
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's right thigh (abrasion) injury
+        character_id: Andrew
+        parameters: { "treatment": "Hemostatic gauze", "location": "right thigh" }
+        probe_id: test-1
+        choice: test-andrew-right-thigh
+      - action_id: treat-andrew-left-calf
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Andrew's left calf (abrasion) injury
+        character_id: Andrew
+        parameters: { "treatment": "Hemostatic gauze", "location": "left calf" }
+        probe_id: test-1
+        choice: test-andrew-left-calf
+    transitions:
+      actions:
+        - [treat-andrew-left-face, treat-andrew-right-bicep, treat-andrew-left-forearm, treat-andrew-right-thigh, treat-andrew-left-calf] # actions within a list have "and" semantics
+
+  - id: fix_adam
+    end_scene_allowed: false
+    state:
+      unstructured: Testing applying hemostatic gauze to shrapnel injuries where a different treatment is called for.
+      characters:
+      - id: Adam
+        name: Adam
+        unstructured: >
+          Patient with multiple shrapnel injuries that require a pressure bandage or airway, but treating with hemostatic gauze will consume the supply.
+        demographics:
+          age: 34
+          sex: M
+          race: White
+        vitals:
+          avpu: ALERT
+          ambulatory: true
+          mental_status: CALM
+          breathing: NORMAL
+          heart_rate: NORMAL
+          spo2: NORMAL
+        injuries:
+          - name: Shrapnel # Hemostatic gauze will be consumed if applied here
+            location: right face
+            status: visible
+          - name: Shrapnel # Hemostatic gauze will be consumed if applied here
+            location: right calf
+            status: visible
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-adam-right-face-with-gauze
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Adam's right face (shrapnel) injury with hemostatic gauze
+        character_id: Adam
+        parameters: { "treatment": "Hemostatic gauze", "location": "right face" }
+        probe_id: test-1
+        choice: treat-adam-right-face-with-gauze
+      - action_id: treat-adam-right-face-with-airway
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Adam's right face (shrapnel) injury with airway
+        character_id: Adam
+        parameters: { "treatment": "Nasopharyngeal airway", "location": "right face" }
+        probe_id: test-1
+        choice: treat-adam-right-face-with-airway
+      - action_id: treat-adam-left-face
+        action_type: APPLY_TREATMENT
+        unstructured: >
+          Apply a Nasopharyngeal airway to Adam's left face (unnecessarily).
+          Note: this will create a warning in the ITM Scenario Validator.
+        character_id: Adam
+        parameters: { "treatment": "Nasopharyngeal airway", "location": "left face" }
+        probe_id: test-1
+        choice: treat-adam-left-face
+      - action_id: treat-adam-right-calf
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Adam's right calf (shrapnel) injury
+        character_id: Adam
+        parameters: { "treatment": "Hemostatic gauze", "location": "right calf" }
+        probe_id: test-1
+        choice: test-adam-right-calf
+    transitions:
+      actions:
+        - [treat-adam-right-face-with-gauze, treat-adam-right-face-with-airway, treat-adam-left-face, treat-adam-right-calf] # actions within a list have "and" semantics

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -75,11 +75,12 @@ class ITMActionHandler:
             Neck Puncture: Hemostatic gauze
             Neck Burn: Burn Dressing 
 
-            Hand Injuries
+            Wrist Injuries
             Wrist Amputation: Tourniquet
             Hand (Palm) Laceration: Pressure bandage
 
             Arm Injuries
+            Forearm Puncture: Tourniquet
             Forearm Laceration: Pressure bandage
             Forearm Burn: Burn Dressing
             Forearm Abrasion: Pressure bandage
@@ -257,6 +258,76 @@ class ITMActionHandler:
         self._reveal_injuries(patient_template, patient)
         patient.visited = True
 
+    # Certain unsuccessful treatments still use supplies
+    def __check_unsuccessful_treatment(self, supply_used, injury_name, location):
+        if supply_used == SupplyTypeEnum.HEMOSTATIC_GAUZE:
+            # Certain misapplications of hemostatic cause will consume the gauze but not treat the injury.
+            if injury_name in [InjuryTypeEnum.ABRASION, InjuryTypeEnum.LACERATION, InjuryTypeEnum.SHRAPNEL]:
+                return True
+            elif injury_name == InjuryTypeEnum.PUNCTURE:
+                return 'bicep' in location or 'forearm' in location or 'thigh' in location or 'calf' in location
+        return False
+
+    def __check_downstream_injuries(self, character_id, all_injuries, treated_injury):
+        """
+        Certain successful tourniquet treatments also treat downstream injuries.
+
+        Args:
+            character_id: The id of the character being treated
+            all_injuries: The full list of character injuries
+            treated_injury: The injury that was treated in the current action
+        """
+        treated_part = 'bicep' if 'bicep' in treated_injury.location else 'thigh' if 'thigh' in treated_injury.location \
+            else 'forearm' if 'forearm' in treated_injury.location else 'irrelevant'
+        treated_injury_type = 'puncture' if treated_injury.name == InjuryTypeEnum.PUNCTURE \
+            else 'laceration' if treated_injury.name == InjuryTypeEnum.LACERATION else 'irrelevant'
+        if treated_part == 'irrelevant' or treated_injury_type == 'irrelevant':
+            return # Doesn't apply
+        treated_side = 'right' if 'right' in treated_injury.location else 'left'
+        downstream_injury = None
+
+        for injury in all_injuries:
+            name = 'puncture' if injury.name == InjuryTypeEnum.PUNCTURE \
+                else 'amputation' if injury.name == InjuryTypeEnum.AMPUTATION else 'irrelevant'
+            side = 'right' if 'right' in injury.location else 'left'
+            part = 'forearm' if 'forearm' in injury.location else 'wrist' if 'wrist' in injury.location \
+                else 'calf' if 'calf' in injury.location else 'irrelevant'
+            if side != treated_side or part == 'irrelevant' or name == 'irrelevant':
+                continue # Doesn't apply
+
+            if treated_part == 'bicep' and treated_injury_type == 'puncture':
+                # Applying a tourniquet to a bicep puncture also treats a forearm puncture or wrist amputation.
+                if (part == 'forearm' and name == 'puncture') or (part == 'wrist' and name == 'amputation'):
+                    downstream_injury = injury
+            elif treated_part == 'forearm' and treated_injury_type == 'puncture':
+                # Applying a tourniquet to a forearm puncture also treats a wrist amputation.
+                if part == 'wrist' and name == 'amputation':
+                    downstream_injury = injury
+            elif treated_part == 'thigh' and (treated_injury_type == 'puncture' or treated_injury_type == 'laceration'):
+                # Applying a tourniquet to a thigh also treats a calf puncture or calf amputation
+                if part == 'calf' and name in ['puncture', 'amputation']:
+                    downstream_injury = injury
+
+        if downstream_injury:
+            self.__treat_injury(character_id, downstream_injury, SupplyTypeEnum.TOURNIQUET)
+
+
+    def __treat_injury(self, character_id, injury, supply_used):
+        logging.info(f"Successfully treated {injury.name} at {injury.location} with {supply_used}.")
+        injury.treatments_applied += 1
+        # Find required treatments for the injury
+        for isd_character in self.current_scene.state.characters:
+            if isd_character.id == character_id:
+                for isd_injury in isd_character.injuries:
+                    if isd_injury.location == injury.location and isd_injury.name == injury.name:
+                        treatments_required = isd_injury.treatments_required
+                        break
+        if injury.treatments_applied < treatments_required:
+            injury.status = InjuryStatusEnum.PARTIALLY_TREATED
+        else:
+            injury.status = InjuryStatusEnum.TREATED
+        logging.debug(f"Setting injury {injury.name} to status {injury.status}")
+
 
     def apply_treatment(self, action: Action, character: Character):
         """
@@ -269,8 +340,10 @@ class ITMActionHandler:
         """
         # If the treatment treats the injury at the specified location, then change its status to treated.
         supply_used = action.parameters.get('treatment')
+        treatment_location = action.parameters.get('location')
         attempted_retreatment = False
         successful_treatment = False
+        consumed_supply = False
         # Note: Anything added to doesnt_treat_injuries is assumed to be automatically successful, which decrements the supply.
         #       If this is not the case, then add an elif branch below (like BLANKET).
         doesnt_treat_injuries = [SupplyTypeEnum.BLANKET, SupplyTypeEnum.BLOOD, SupplyTypeEnum.EPI_PEN, SupplyTypeEnum.FENTANYL_LOLLIPOP, \
@@ -278,31 +351,29 @@ class ITMActionHandler:
         if supply_used not in doesnt_treat_injuries:
             for injury in character.injuries:
                 logging.debug(f"Processing injury {injury.name} at location {injury.location} with status {injury.status} with supply {supply_used}.")
-                if injury.location == action.parameters.get('location'):
+                if injury.location == treatment_location:
                     logging.debug(f"Found {injury.name} injury at location {injury.location}.")
                     if injury.status != InjuryStatusEnum.TREATED: # Can't attempt to treat a treated injury
                         logging.debug(f"Attempting to treat injury {injury.name} at location {injury.location} with {supply_used}.")
                         if self.__successful_treatment(supply_used, injury.name, injury.location):
                             successful_treatment = True
-                            logging.info(f"Successfully treated {injury.name} at {injury.location} with {supply_used}.")
-                            injury.treatments_applied += 1
-                            # Find required treatments for the injury
-                            for isd_character in self.current_scene.state.characters:
-                                if isd_character.id == character.id:
-                                    for isd_injury in isd_character.injuries:
-                                        if isd_injury.location == injury.location and isd_injury.name == injury.name:
-                                            treatments_required = isd_injury.treatments_required
-                                            break
-                            if injury.treatments_applied < treatments_required:
-                                injury.status = InjuryStatusEnum.PARTIALLY_TREATED
-                            else:
-                                injury.status = InjuryStatusEnum.TREATED
-                            logging.debug(f"Setting injury {injury.name} to status {injury.status}")
+                            self.__treat_injury(character.id, injury, supply_used)
+                            if supply_used == SupplyTypeEnum.TOURNIQUET:
+                                self.__check_downstream_injuries(character.id, character.injuries, injury)
                         else:
                             logging.info(f"Unsuccessfully treated {injury.name} at {injury.location} with {supply_used}.")
+                            consumed_supply = self.__check_unsuccessful_treatment(supply_used, injury.name, injury.location)
                     else:
                         logging.debug(f"Attempted retreatment of injury {injury.name} at location {injury.location}.")
                         attempted_retreatment = True
+            if not successful_treatment:
+                if supply_used == SupplyTypeEnum.DECOMPRESSION_NEEDLE:
+                    # Decompression needles can be placed anywhere in any quantity, even if there's no injury, consuming supplies.
+                    consumed_supply = True
+                elif supply_used == SupplyTypeEnum.NASOPHARYNGEAL_AIRWAY:
+                    # Airways can be placed in the nose even if there's no injury, consuming supplies.
+                    # Only one airway should be able to be placed per nostril, see ITM-643.
+                    consumed_supply = treatment_location == InjuryLocationEnum.RIGHT_FACE or InjuryLocationEnum.LEFT_FACE
         elif (supply_used == SupplyTypeEnum.BLANKET):
             if character.has_blanket:
                 attempted_retreatment = True
@@ -319,7 +390,7 @@ class ITMActionHandler:
         time_passed = 0
         for supply in self.session.state.supplies:
             if supply.type == supply_used:
-                if successful_treatment and not supply.reusable:
+                if (successful_treatment or consumed_supply) and not supply.reusable:
                     supply.quantity -= 1
                     logging.debug(f"Decrementing {supply.type} to {supply.quantity}")
                 if supply_used in self.times_dict["treatmentTimes"]:
@@ -354,7 +425,7 @@ class ITMActionHandler:
 
     def check_blood_oxygen(self, character: Character):
         """
-        Process checking the blood oxygen level (Sp02) of the specified character.
+        Process checking the blood oxygen level (spo2) of the specified character.
 
         Args:
             character: The character to check.

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -89,7 +89,7 @@ class ITMActionHandler:
             Bicep Laceration: Tourniquet
             Bicep Puncture: Tourniquet
             Bicep Abrasion: Pressure bandage
-            Shoulder Laceration: Tourniquet
+            Shoulder Laceration: Hemostatic gauze
             Shoulder Puncture: Hemostatic gauze
             Broken Shoulder: Splint
 
@@ -132,14 +132,14 @@ class ITMActionHandler:
             case InjuryTypeEnum.ABRASION:
                 return treatment == SupplyTypeEnum.PRESSURE_BANDAGE
             case InjuryTypeEnum.LACERATION:
-                if 'thigh' in location or 'bicep' in location or 'shoulder' in location:
+                if location in ['thigh', 'bicep']:
                     return treatment == SupplyTypeEnum.TOURNIQUET
-                elif 'stomach' in location or 'chest' in location or 'neck' in location:
+                elif location in ['stomach', 'chest', 'neck', 'shoulder']:
                     return treatment == SupplyTypeEnum.HEMOSTATIC_GAUZE
                 else:
                     return treatment == SupplyTypeEnum.PRESSURE_BANDAGE
             case InjuryTypeEnum.PUNCTURE:
-                if 'forearm' in location or 'bicep' in location or 'thigh' in location or 'calf' in location:
+                if location in ['forearm', 'bicep', 'thigh', 'calf']:
                     return treatment == SupplyTypeEnum.TOURNIQUET
                 elif 'chest' in location:
                     return treatment == SupplyTypeEnum.VENTED_CHEST_SEAL
@@ -283,22 +283,23 @@ class ITMActionHandler:
             all_injuries: The full list of character injuries
             treated_injury: The injury that was treated in the current action
         """
+        IRRELEVANT = 'irrelevant'
         treated_part = 'bicep' if 'bicep' in treated_injury.location else 'thigh' if 'thigh' in treated_injury.location \
-            else 'forearm' if 'forearm' in treated_injury.location else 'irrelevant'
+            else 'forearm' if 'forearm' in treated_injury.location else IRRELEVANT
         treated_injury_type = 'puncture' if treated_injury.name == InjuryTypeEnum.PUNCTURE \
-            else 'laceration' if treated_injury.name == InjuryTypeEnum.LACERATION else 'irrelevant'
-        if treated_part == 'irrelevant' or treated_injury_type == 'irrelevant':
+            else 'laceration' if treated_injury.name == InjuryTypeEnum.LACERATION else IRRELEVANT
+        if treated_part is IRRELEVANT or treated_injury_type is IRRELEVANT:
             return # Doesn't apply
         treated_side = 'right' if 'right' in treated_injury.location else 'left'
         downstream_injury = None
 
         for injury in all_injuries:
             name = 'puncture' if injury.name == InjuryTypeEnum.PUNCTURE \
-                else 'amputation' if injury.name == InjuryTypeEnum.AMPUTATION else 'irrelevant'
+                else 'amputation' if injury.name == InjuryTypeEnum.AMPUTATION else IRRELEVANT
             side = 'right' if 'right' in injury.location else 'left'
             part = 'forearm' if 'forearm' in injury.location else 'wrist' if 'wrist' in injury.location \
-                else 'calf' if 'calf' in injury.location else 'irrelevant'
-            if side != treated_side or part == 'irrelevant' or name == 'irrelevant':
+                else 'calf' if 'calf' in injury.location else IRRELEVANT
+            if side != treated_side or part is IRRELEVANT or name is IRRELEVANT:
                 continue # Doesn't apply
 
             if treated_part == 'bicep' and treated_injury_type == 'puncture':

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -72,6 +72,7 @@ class ITMActionHandler:
             Traumatic Brain Injury: None
 
             Neck Injuries
+            Neck Laceration: Hemostatic gauze
             Neck Puncture: Hemostatic gauze
             Neck Burn: Burn Dressing 
 
@@ -85,8 +86,10 @@ class ITMActionHandler:
             Forearm Burn: Burn Dressing
             Forearm Abrasion: Pressure bandage
             Bicep Burn: Burn Dressing
+            Bicep Laceration: Tourniquet
             Bicep Puncture: Tourniquet
             Bicep Abrasion: Pressure bandage
+            Shoulder Laceration: Tourniquet
             Shoulder Puncture: Hemostatic gauze
             Broken Shoulder: Splint
 
@@ -94,10 +97,11 @@ class ITMActionHandler:
             Asthmatic: None
             Chest Burn: Burn Dressing
             Chest Collapse: Decompression Needle
+            Chest Laceration: Hemostatic gauze
             Chest Puncture: Vented Chest Seal
 
             Stomach Injuries
-            Stomach Laceration: Pressure bandage
+            Stomach Laceration: Hemostatic gauze
             Stomach Puncture: Hemostatic gauze
             Side Puncture: Hemostatic gauze
             Open Abdominal Wound: None
@@ -128,8 +132,10 @@ class ITMActionHandler:
             case InjuryTypeEnum.ABRASION:
                 return treatment == SupplyTypeEnum.PRESSURE_BANDAGE
             case InjuryTypeEnum.LACERATION:
-                if 'thigh' in location:
+                if 'thigh' in location or 'bicep' in location or 'shoulder' in location:
                     return treatment == SupplyTypeEnum.TOURNIQUET
+                elif 'stomach' in location or 'chest' in location or 'neck' in location:
+                    return treatment == SupplyTypeEnum.HEMOSTATIC_GAUZE
                 else:
                     return treatment == SupplyTypeEnum.PRESSURE_BANDAGE
             case InjuryTypeEnum.PUNCTURE:
@@ -367,10 +373,7 @@ class ITMActionHandler:
                         logging.debug(f"Attempted retreatment of injury {injury.name} at location {injury.location}.")
                         attempted_retreatment = True
             if not successful_treatment:
-                if supply_used == SupplyTypeEnum.DECOMPRESSION_NEEDLE:
-                    # Decompression needles can be placed anywhere in any quantity, even if there's no injury, consuming supplies.
-                    consumed_supply = True
-                elif supply_used == SupplyTypeEnum.NASOPHARYNGEAL_AIRWAY:
+                if supply_used == SupplyTypeEnum.NASOPHARYNGEAL_AIRWAY:
                     # Airways can be placed in the nose even if there's no injury, consuming supplies.
                     # Only one airway should be able to be placed per nostril, see ITM-643.
                     consumed_supply = treatment_location == InjuryLocationEnum.RIGHT_FACE or InjuryLocationEnum.LEFT_FACE


### PR DESCRIPTION
Several changes were made to be more in sync with the simulator:

- Successful treatments for new injuries:
  - stomach laceration: hemostatic gauze
  - chest laceration: hemostatic gauze
  - neck laceration: hemostatic gauze
  - shoulder laceration: hemostatic gauze
  - bicep laceration: tourniquet
- Hemostatic gauze consumption:
  - use hemo gauze instead of tourniquet on untreated punctures consumes supply
  - use hemo gauze instead of pressure bandage/tourniquet on untreated lacerations consumes supply
  - use hemo gauze instead of pressure bandage on untreated abrasions consumes supply
  - use hemo gauze instead of pressure bandage/airway on untreated leg/face shrapnel consumes supply
- ~~Decompression needles can be placed anywhere in any quantity, consuming supplies~~
- Using an airway (on right or left face) always consumes a supply, even if no injury; can be done twice
- Tourniquet treatments on an upper arm/leg also treat downstream injuries that require a tourniquet:
   - Applying a tourniquet to a bicep puncture also treats a forearm puncture;
   - Applying a tourniquet to a bicep puncture also treats a wrist amputation;
   - Applying a tourniquet to a forearm puncture also treats a wrist amputation;
   - Applying a tourniquet to a thigh puncture also treats a calf puncture;
   - Applying a tourniquet to a thigh puncture also treats a calf amputation;
   - Applying a tourniquet to a thigh laceration also treats a calf puncture; and
   - Applying a tourniquet to a thigh laceration also treats a calf amputation

To test, ensure that you think the new test, `downstream_injuries`, tests this new functionality, and tweak the test as you see fit to ensure the above was correctly implemented.  It also doesn't hurt to re-run standalone (or integrated) `soartech`, `adept`, and/or `eval` sessions.

NOTE: this PR was made prior to post-phase 1 changes to the scenario runner (ITM-563, [PR#115](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/115)), so you might need to add `ALWAYS_CONNECT_TO_TA1` back to your `config.ini`.  Set it to false for standalone tests and true if running integrated soartech/adept sessions.