### PR TITLE
Support running of ADEPT Phase 1 scenarios with multi targets generated from human participants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ EXPOSE 8080
 
 ENTRYPOINT ["python3"]
 
-CMD ["-m", "swagger_server", "-c", "GROUP_TARGET"]
+CMD ["-m", "swagger_server"]
 

--- a/swagger_server/config.ini.template
+++ b/swagger_server/config.ini.template
@@ -26,8 +26,8 @@ ALWAYS_CONNECT_TO_TA1=True
 HISTORY_DIRECTORY=itm_history_output
 HISTORY_S3_BUCKET=itm-ui-assets
 
-EVAL_NAME=Phase 1 Evaluation
-EVAL_NUMBER=5
+EVAL_NAME=Phase II E1
+EVAL_NUMBER=7
 
 SOARTECH_EVAL_FILENAMES=phase1-soartech-eval-qol2.yaml,
     phase1-soartech-eval-qol3.yaml,

--- a/swagger_server/itm/itm_alignment_target_reader.py
+++ b/swagger_server/itm/itm_alignment_target_reader.py
@@ -7,7 +7,9 @@ from swagger_server.models import (
 class ITMAlignmentTargetReader:
     """Class for converting YAML data to ITM scenarios."""
 
-    def __init__(self, yaml_path: str):
+    COUNTER: int = 1
+
+    def init_from_yaml(self, yaml_path: str):
         """
         Initialize the class with YAML data from a file path.
 
@@ -20,6 +22,26 @@ class ITMAlignmentTargetReader:
                 id=self.yaml_data['id'],
                 kdma_values=self._extract_alignment_targets()
             )
+
+    def init_from_kdmas(self, mj: float, io: float):
+        """
+        Initialize the class with the specified KDMA values.
+
+        Args:
+            mj: a Moral judgement KDMA value.
+            io: an Ingroup Bias KDMA value.
+        """
+        self.alignment_target = AlignmentTarget(
+            id=f"target{ITMAlignmentTargetReader.COUNTER}",
+            kdma_values=self._extract_kdma_values(mj, io)
+        )
+        ITMAlignmentTargetReader.COUNTER += 1
+
+    def _extract_kdma_values(self, mj: float, io: float):
+        kdma_values = []
+        kdma_values.append(KDMAValue(kdma='Moral judgement', value=mj))
+        kdma_values.append(KDMAValue(kdma='Ingroup Bias', value=io))
+        return kdma_values
 
     def _extract_alignment_targets(self):
         alignment_targets = []

--- a/swagger_server/itm/itm_ta1_controller.py
+++ b/swagger_server/itm/itm_ta1_controller.py
@@ -93,7 +93,7 @@ class ITMTa1Controller:
             actual_target_id = self.alignment_target_id if not target_id else target_id
             params = {
                 "session_id_1_or_target_id": self.session_id,
-                "session_id_2_or_target_id": actual_target_id,
+                "session_id_2_or_target_id": "ADEPT-DryRun-Moral judgement-0.2", # ITM-893 specific hack
                 "target_pop_id": ITMTa1Controller.ADEPT_MJ_ALIGNMENT_DISTRIBUTION_TARGET if 'Moral' in actual_target_id \
                     else ITMTa1Controller.ADEPT_IO_ALIGNMENT_DISTRIBUTION_TARGET
             }

--- a/swagger_server/itm/itm_ta1_controller.py
+++ b/swagger_server/itm/itm_ta1_controller.py
@@ -2,6 +2,7 @@ import requests
 import json
 import urllib
 import builtins
+from math import isnan
 from swagger_server.models.probe_response import ProbeResponse  # noqa: F401,E501
 from swagger_server.models.alignment_results import AlignmentResults  # noqa: F401,E501
 from swagger_server.models.alignment_target import AlignmentTarget  # noqa: F401,E501
@@ -108,6 +109,11 @@ class ITMTa1Controller:
         initial_response.raise_for_status()
         response = self.to_dict(initial_response)
         alignment_results :AlignmentResults = AlignmentResults.from_dict(response)
+        if isnan(alignment_results.score):
+            alignment_results = AlignmentResults(
+                alignment_source=alignment_results.alignment_source,
+                alignment_target_id=alignment_results.alignment_target_id,
+                kdma_values=alignment_results.kdma_values)
 
         # Need to get KDMAs from a separate endpoint.
         base_url = f"{self.url}/api/v1/computed_kdma_profile"


### PR DESCRIPTION
***THIS PR IS READY FOR REVIEW BUT WILL NOT BE MERGED***

This branch takes the output from [ITM-892](https://nextcentury.atlassian.net/browse/ITM-892) (which pulls out the KDMAs from human participants to use as targets for ADMs) and creates synthetic alignment targets out of them, such that when ADMs request an `adept` session, the ADEPT Phase 1 scenarios will be served up once per synthetic target.  This is about 500 targets times 3 evaluation scenarios.

The branch expects a file in the server root directory named `text_kdmas.csv`, which is the output from ITM-892 (see [the PR](https://github.com/NextCenturyCorporation/itm-ingest/pull/114)).  For testing purposes, you might want to cull it down to a manageable number of rows.  Make sure your `config.ini` has the same values for `EVAL_NAME` and `EVAL_NUMBER` as the template (`config.ini.template`) and that `SAVE_HISTORY` = True.  You might want to copy the template from this branch, then tweak for your env as necessary.  Then test with the client:
- `python itm_minimal_runner.py --session adept --name itm893`

Note that session alignment is irrelevant here (it will always be NaN).  Make sure that the resulting JSON file contains the TA1 session ID, MJ alignment target, IO alignment target (these are carried forward from the list in ITM-892), the scenario ID, and the MJ and IO KDMA measurements from the TA1 server.

[ITM-892]: https://nextcentury.atlassian.net/browse/ITM-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ