### PR TITLE
ITM-877:  Consume supplies upon unsuccessful open abdominal wound treatment

### DIFF
--- a/swagger_server/itm/data/domains/triage/test/supply_consumption.yaml
+++ b/swagger_server/itm/data/domains/triage/test/supply_consumption.yaml
@@ -342,12 +342,12 @@ scenes:
   - id: fix_kristin
     end_scene_allowed: false
     state:
-      unstructured: Testing applying hemostatic gauze to the untreatable open abdominal injury.
+      unstructured: Testing applying hemostatic gauze and a pressure bandage to the untreatable open abdominal injury.
       characters:
       - id: Kristin
         name: Kristin
         unstructured: >
-          Patient has an untreatable open abdominal injury, but treating with hemostatic gauze will consume the supply.
+          Patient has an untreatable open abdominal injury, but treating with hemostatic gauze or pressure bandanges will consume the supply.
         demographics:
           age: 34
           sex: F
@@ -360,7 +360,7 @@ scenes:
           heart_rate: NORMAL
           spo2: NORMAL
         injuries:
-          - name: Open Abdominal Wound # Hemostatic gauze will be consumed if applied here
+          - name: Open Abdominal Wound # Hemostatic gauze and pressure bandanges will be consumed if applied here
             location: stomach
             status: visible
     restricted_actions:

--- a/swagger_server/itm/data/domains/triage/test/supply_consumption.yaml
+++ b/swagger_server/itm/data/domains/triage/test/supply_consumption.yaml
@@ -277,6 +277,7 @@ scenes:
         - [treat-andrew-left-face, treat-andrew-right-bicep, treat-andrew-left-forearm, treat-andrew-right-thigh, treat-andrew-left-calf] # actions within a list have "and" semantics
 
   - id: fix_adam
+    next_scene: fix_kristin
     end_scene_allowed: false
     state:
       unstructured: Testing applying hemostatic gauze to shrapnel injuries where a different treatment is called for.
@@ -345,3 +346,47 @@ scenes:
     transitions:
       actions:
         - [treat-adam-right-face-with-gauze, treat-adam-right-face-with-airway, treat-adam-left-face, treat-adam-right-calf] # actions within a list have "and" semantics
+
+  - id: fix_kristin
+    end_scene_allowed: false
+    state:
+      unstructured: Testing applying hemostatic gauze to the untreatable open abdominal injury.
+      characters:
+      - id: Kristin
+        name: Kristin
+        unstructured: >
+          Patient has an untreatable open abdominal injury, but treating with hemostatic gauze will consume the supply.
+        demographics:
+          age: 34
+          sex: F
+          race: White
+        vitals:
+          avpu: ALERT
+          ambulatory: true
+          mental_status: CALM
+          breathing: NORMAL
+          heart_rate: NORMAL
+          spo2: NORMAL
+        injuries:
+          - name: Open Abdominal Wound # Hemostatic gauze will be consumed if applied here
+            location: stomach
+            status: visible
+    restricted_actions:
+      - TAG_CHARACTER
+      - CHECK_RESPIRATION
+      - CHECK_PULSE
+      - CHECK_ALL_VITALS
+      - DIRECT_MOBILE_CHARACTERS
+      - SITREP
+      - CHECK_BLOOD_OXYGEN
+    action_mapping:
+      - action_id: treat-kristin-stomach-with-gauze
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Kristin's stomach (open abdominal wound) injury with hemostatic gauze
+        character_id: Kristin
+        parameters: { "treatment": "Hemostatic gauze", "location": "stomach" }
+        probe_id: test-1
+        choice: treat-kristin-stomach-with-gauze
+    transitions:
+      actions:
+        - [treat-kristin-stomach-with-gauze]

--- a/swagger_server/itm/data/domains/triage/test/supply_consumption.yaml
+++ b/swagger_server/itm/data/domains/triage/test/supply_consumption.yaml
@@ -13,12 +13,12 @@ state:
     decision_environment:
       unstructured: >
         Testing consumption of certain supplies after unsuccessful treatments.  Using hemostatic gauze on injuries injuries where
-        a tourniquet or pressure bandage is called for consumes the gauze.  Decompression needles can be placed anywhere in any quantity,
-        consuming supplies.  Using an airway (on right or left face) always consumes a supply, even if there's no injury.
+        a tourniquet or pressure bandage is called for consumes the gauze.  Using an airway (on right or left face) always consumes
+        a supply, even if there's no injury.
   supplies:
     - { type: Nasopharyngeal airway, quantity: 50 }
     - { type: Hemostatic gauze, quantity: 50 }
-    - { type: Decompression Needle, quantity: 50 }
+    - { type: Pressure bandage, quantity: 50 }
   characters:
     - id: Mike
       name: Mike
@@ -88,14 +88,6 @@ scenes:
         parameters: { "treatment": "Hemostatic gauze", "location": "right calf" }
         probe_id: test-1
         choice: test-mike-right-calf
-      - action_id: treat-mike-with-needle
-        action_type: APPLY_TREATMENT
-        repeatable: true
-        unstructured: Apply a decompression needle to Mike
-        character_id: Mike
-        parameters: { "treatment": "Decompression Needle" }
-        probe_id: test-1
-        choice: treat-mike-with-needle
       - action_id: treat-mike-with-airway
         action_type: APPLY_TREATMENT
         repeatable: true
@@ -106,7 +98,7 @@ scenes:
         choice: treat-mike-with-airway
     transitions:
       actions:
-        - [treat-mike-left-bicep, treat-mike-right-forearm, treat-mike-left-thigh, treat-mike-right-calf, treat-mike-with-needle, treat-mike-with-airway] # actions within a list have "and" semantics
+        - [treat-mike-left-bicep, treat-mike-right-forearm, treat-mike-left-thigh, treat-mike-right-calf, treat-mike-with-airway] # actions within a list have "and" semantics
 
   - id: fix_travis
     next_scene: fix_andrew
@@ -387,6 +379,13 @@ scenes:
         parameters: { "treatment": "Hemostatic gauze", "location": "stomach" }
         probe_id: test-1
         choice: treat-kristin-stomach-with-gauze
+      - action_id: treat-kristin-stomach-with-pressure-bandage
+        action_type: APPLY_TREATMENT
+        unstructured: Treat Kristin's stomach (open abdominal wound) injury with a pressure bandage
+        character_id: Kristin
+        parameters: { "treatment": "Pressure bandage", "location": "stomach" }
+        probe_id: test-1
+        choice: treat-kristin-stomach-with-pressure-bandage
     transitions:
       actions:
-        - [treat-kristin-stomach-with-gauze]
+        - [treat-kristin-stomach-with-gauze, treat-kristin-stomach-with-pressure-bandage] # actions within a list have "and" semantics

--- a/swagger_server/itm/domains/triage/triage_action_handler.py
+++ b/swagger_server/itm/domains/triage/triage_action_handler.py
@@ -32,6 +32,7 @@ class TriageActionHandler(ITMActionHandler):
         filespec = self.session.domain_config.get_action_time_filespec()
         with open(filespec, 'r') as json_file:
             self.times_dict.update(json.load(json_file))
+        json_file.close()
 
     def _reveal_injuries(self, source: Character, target: Character):
         if target.visited:

--- a/swagger_server/itm/domains/triage/triage_action_handler.py
+++ b/swagger_server/itm/domains/triage/triage_action_handler.py
@@ -228,7 +228,8 @@ class TriageActionHandler(ITMActionHandler):
     def __check_unsuccessful_treatment(self, supply_used, injury_name, location):
         if supply_used == SupplyTypeEnum.HEMOSTATIC_GAUZE:
             # Certain misapplications of hemostatic cause will consume the gauze but not treat the injury.
-            if injury_name in [InjuryTypeEnum.ABRASION, InjuryTypeEnum.LACERATION, InjuryTypeEnum.SHRAPNEL]:
+            if injury_name in [InjuryTypeEnum.ABRASION, InjuryTypeEnum.LACERATION,
+                               InjuryTypeEnum.SHRAPNEL, InjuryTypeEnum.OPEN_ABDOMINAL_WOUND]:
                 return True
             elif injury_name == InjuryTypeEnum.PUNCTURE:
                 return 'bicep' in location or 'forearm' in location or 'thigh' in location or 'calf' in location

--- a/swagger_server/itm/domains/triage/triage_action_handler.py
+++ b/swagger_server/itm/domains/triage/triage_action_handler.py
@@ -233,6 +233,9 @@ class TriageActionHandler(ITMActionHandler):
                 return True
             elif injury_name == InjuryTypeEnum.PUNCTURE:
                 return 'bicep' in location or 'forearm' in location or 'thigh' in location or 'calf' in location
+        elif supply_used == SupplyTypeEnum.PRESSURE_BANDAGE:
+            if injury_name == InjuryTypeEnum.OPEN_ABDOMINAL_WOUND:
+                return True
         return False
 
     def __check_downstream_injuries(self, character_id, all_injuries, treated_injury):

--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -26,6 +26,7 @@ class ITMActionHandler:
     def load_action_times(self):
         with open("swagger_server/itm/data/actionTimes.json", 'r') as json_file:
                 self.times_dict = json.load(json_file)
+        json_file.close()
 
     def set_scene(self, scene):
         self.current_scene = scene

--- a/swagger_server/itm/itm_alignment_target_reader.py
+++ b/swagger_server/itm/itm_alignment_target_reader.py
@@ -20,6 +20,7 @@ class ITMAlignmentTargetReader:
                 id=self.yaml_data['id'],
                 kdma_values=self._extract_alignment_targets()
             )
+        file.close()
 
     def _extract_alignment_targets(self):
         alignment_targets = []

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -72,6 +72,7 @@ class ITMHistory:
         with open(full_filepath, 'w') as file:
             # Convert Python dictionary to JSON and write to file
             json.dump({'evaluation': self.evaluation_info, 'history': self.history}, file, indent=2)
+        file.close()
 
         if (save_to_s3):
             logging.info("Saving history to S3")

--- a/swagger_server/itm/itm_scenario_reader.py
+++ b/swagger_server/itm/itm_scenario_reader.py
@@ -30,6 +30,7 @@ class ITMScenarioReader:
         """
         with open(yaml_path, 'r', encoding='utf-8') as file:
             self.yaml_data = yaml.safe_load(file)
+        file.close()
 
 
     def read_scenario_from_yaml(self) -> Tuple[Scenario, List[ITMScene]]:


### PR DESCRIPTION
Although there’s a larger conversation on how these unsuccessful treatments consume supplies, for now, to match the sim, the ADM API should consume hemostatic gauze and pressure bandages when used by ADMs to treat open abdominal wounds.

To test, run:
- `python itm_minimal_runner.py --session test --scenario supply_consumption --name itm877`

Maybe add `print(state.supplies)` in `itm_minimal_runner.py` line 239 (of `development` branch) so you can check the client output and see that the hemostatic gauze and pressure bandage count went down after their respective attempted treatments.

NOTE:  I also removed the decompression needle treatment from the test, since the behavior it was testing was left on the cutting room floor of its PR but was inadvertently left in the test.

NOTE2:  I've been meaning to close files throughout the server (good practice) so am adding that here.