### PR TITLE
ITM-715:  Add metadata to server output

### DIFF
--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -28,9 +28,23 @@ class ITMHistory:
 
     def clear_history(self):
         self.history.clear()
+        if self.evaluation_info.get('scenario_name'): # Did user set metadata?
+            self.evaluation_info.pop('scenario_name')
+            self.evaluation_info.pop('scenario_id')
+            self.evaluation_info.pop('alignment_target_id')
+            self.evaluation_info.pop('adm_name')
+            self.evaluation_info.pop('ta1_name')
+            self.evaluation_info.pop('ta3_session_id')
+            self.evaluation_info.pop('ta1_session_id')
 
-    def get_history(self):
-        return self.history
+    def set_metadata(self, scenario_name, scenario_id, alignment_target_id, adm_name, ta1_name, ta3_session_id, ta1_session_id):
+        self.evaluation_info['scenario_name'] = scenario_name
+        self.evaluation_info['scenario_id'] = scenario_id
+        self.evaluation_info['alignment_target_id'] = alignment_target_id
+        self.evaluation_info['adm_name'] = adm_name
+        self.evaluation_info['ta1_name'] = ta1_name
+        self.evaluation_info['ta3_session_id'] = ta3_session_id
+        self.evaluation_info['ta1_session_id'] = ta1_session_id
 
     def add_history(self,
                     command: str,

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -154,7 +154,7 @@ class ITMSession:
         self.state.scenario_complete = True
 
         if self.kdma_training:
-            self.state.unstructured = 'Scenario complete.'
+            self.state.unstructured = f"Scenario {self.itm_scenario.id} complete."
             self._cleanup()
             return
 
@@ -189,6 +189,15 @@ class ITMSession:
 
 
     def _cleanup(self):
+        self.history.set_metadata(
+            scenario_name=self.itm_scenario.name,
+            scenario_id=self.itm_scenario.id,
+            alignment_target_id=self.itm_scenario.alignment_target.id,
+            adm_name=self.adm_name,
+            ta1_name=self.itm_scenario.ta1_name,
+            ta3_session_id=self.session_id,
+            ta1_session_id=self.itm_scenario.ta1_controller.session_id if self.itm_scenario.ta1_controller else None
+            )
         if self.save_history:
             kdma = self.itm_scenario.alignment_target.kdma_values[0].kdma.split(" ")[0].lower()
             alignment_type = kdma + "-" + self.itm_scenario.alignment_target.id
@@ -197,10 +206,10 @@ class ITMSession:
             filename += f"{ITMSession.EVALUATION_TYPE.replace(' ','')}-{self.itm_scenario.id.replace(' ', '_')}-{self.itm_scenario.ta1_name}-{alignment_type.replace(' ', '_')}-{self.adm_name}-{timestamp}"
             self.history.write_to_json_file(filename, self.save_history_to_s3)
         if self.return_scenario_history:
-            if builtins.testing:
-                self.state.unstructured = "Full session history"
+            if builtins.testing: # Don't print full history
+                self.state.unstructured = dumps({'metadata': self.history.evaluation_info}, indent=2) + os.linesep + self.state.unstructured
             else:
-                self.state.unstructured = dumps({'history': self.history.history}, indent=2) + os.linesep + self.state.unstructured
+                self.state.unstructured = dumps({'history': self.history.history, 'metadata': self.history.evaluation_info}, indent=2) + os.linesep + self.state.unstructured
         self.history.clear_history()
 
 


### PR DESCRIPTION
Sometimes the first item in "history" is start scenario but other times it is start session, so not all the history files are exactly the same structure.  Duplicating certain fields to the initial evaluation section would make it easier on downstream components:
- scenario name
- scenario id
- alignment target
- adm name
- ta1 name
- ta3 session id
- ta1 session id

To test, try out different session types and check out the `evaluation` section of the JSON output or `metadata` of training `stdout`, some in server test mode (`-t`) and others in regular mode. e.g.:
- `python itm_minimal_runner.py --session test --name test`
- `python itm_minimal_runner.py --session adept --name adept`
- `python itm_minimal_runner.py --session soartech --name soartech`
- `python itm_minimal_runner.py --name adeptrain--session adept --training solo`
- `python itm_minimal_runner.py --name soartrain --session soartech --training full --scenario qol-ph1-train-3`