### PR TITLE
ITM-497:  Add action validation to API

### DIFF
--- a/swagger/base_swagger.yaml
+++ b/swagger/base_swagger.yaml
@@ -445,7 +445,7 @@ paths:
                 type: string
                 x-content-type: text/plain
           description: An exception occurred on the server; see returned error string.
-      summary: Take an action within a scenario
+      summary: Validate an action within a scenario
       tags:
       - itm-ta2-eval
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller

--- a/swagger/base_swagger.yaml
+++ b/swagger/base_swagger.yaml
@@ -405,6 +405,50 @@ paths:
                 type: string
                 x-content-type: text/plain
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
+  /ta2/validateAction:
+    post:
+      description: Validate that the specified Action is structually and contextually valid within a scenario
+      operationId: validate_action
+      parameters:
+      - description: "a unique session_id, as returned by /ta2/startSession"
+        explode: true
+        in: query
+        name: session_id
+        required: true
+        schema:
+          type: string
+        style: form
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Action"
+        description: Encapsulation of an action to be validated by a DM in the context of the
+          scenario
+      responses:
+        "200":
+          description: "Successful operation, returns 'valid action'/'valid intention'
+            if the action/intention is valid, otherwise a string describing why it is invalid"
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: "'valid action'/'valid intention' if the action/intention is valid,
+                  otherwise a string describing why it is invalid"
+                x-content-type: text/plain
+        "400":
+          description: "Invalid Session ID"
+        "500":
+          content:
+            text/plain:
+              schema:
+                type: string
+                x-content-type: text/plain
+          description: An exception occurred on the server; see returned error string.
+      summary: Take an action within a scenario
+      tags:
+      - itm-ta2-eval
+      x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
 components:
   schemas:
     Scenario:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -356,7 +356,7 @@ paths:
                 type: string
                 x-content-type: text/plain
           description: An exception occurred on the server; see returned error string.
-      summary: Take an action within a scenario
+      summary: Validate an action within a scenario
       tags:
       - itm-ta2-eval
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -314,6 +314,52 @@ paths:
       tags:
       - itm-ta2-eval
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
+  /ta2/validateAction:
+    post:
+      description: Validate that the specified Action is structually and contextually
+        valid within a scenario
+      operationId: validate_action
+      parameters:
+      - description: "a unique session_id, as returned by /ta2/startSession"
+        explode: true
+        in: query
+        name: session_id
+        required: true
+        schema:
+          type: string
+        style: form
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Action"
+        description: Encapsulation of an action to be validated by a DM in the context
+          of the scenario
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                description: "'valid action'/'valid intention' if the action/intention\
+                  \ is valid, otherwise a string describing why it is invalid"
+                type: string
+                x-content-type: text/plain
+          description: "Successful operation, returns 'valid action'/'valid intention'\
+            \ if the action/intention is valid, otherwise a string describing why\
+            \ it is invalid"
+        "400":
+          description: Invalid Session ID
+        "500":
+          content:
+            text/plain:
+              schema:
+                type: string
+                x-content-type: text/plain
+          description: An exception occurred on the server; see returned error string.
+      summary: Take an action within a scenario
+      tags:
+      - itm-ta2-eval
+      x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
   /ta2/{scenario_id}/getAvailableActions:
     get:
       description: Retrieve a list of currently available actions in the scenario

--- a/swagger_server/controllers/itm_ta2_eval_controller.py
+++ b/swagger_server/controllers/itm_ta2_eval_controller.py
@@ -200,3 +200,22 @@ def intend_action(session_id, body=None):  # noqa: E501
 
     session = _get_session(session_id)
     return session.intend_action(body=body) if session else ('Invalid Session ID', 400)
+
+
+def validate_action(session_id, body=None):  # noqa: E501
+    """Validate that the specified Action is structually and contextually valid within a scenario
+
+    Validate that the specified Action is structually and contextually valid within a scenario # noqa: E501
+
+    :param session_id: a unique session_id, as returned by /ta2/startSession
+    :type session_id: str
+    :param body: Encapsulation of an action to be validated by a DM in the context of the scenario
+    :type body: dict | bytes
+
+    :rtype: Union[boolean, Tuple[str, int], Tuple[str, int, Dict[str, str]]
+    """
+    if connexion.request.is_json:
+        body = Action.from_dict(connexion.request.get_json())  # noqa: E501
+
+    session = _get_session(session_id)
+    return session.validate_action(body=body) if session else ('Invalid Session ID', 400)


### PR DESCRIPTION
See [ticket](https://nextcentury.atlassian.net/browse/ITM-497) and [client PR](https://github.com/NextCenturyCorporation/itm-evaluation-client/pull/71).

Exposed server-side action validation code via a simple endpoint.

To test, verify that normal operations still work (`test`, `adept`, `soartech` sessions).  You shouldn't need the TA1 servers, so you can launch the server with the `-t` option.  You also might try hacking the `itm_minimal_client.py` to make some invalid actions (both regular and intent actions) to see that the API catches invalid actions.
For example, near the beginning of the client's `get_net_action()` function, add:
```
        if random_action.intent_action:
            random_action.character_id = 'foobar'
```
or something like that.  Or change `get_random_supply()` to return `foobar` instead.