### PR TITLE
ITM-488:  Improve simultaneous session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ The following properties can be configured:
 *NOTE:* the trailing **`s`** in `.../data/%(EVALUATION_TYPE)s/...` is needed for string interpolation to work properly.
 
 ### Scenario filename convention
-Scenario files must be named in the following format to be read by the server at runtime (without punctuation except the indicated hyphens).
-This is the same convention used in the metrics evaluation:
+Scenario files should be named in the following format (without punctuation except the indicated hyphens).
+This was the convention used in the (Phase 1) Dry Run evaluation:
 - `<EVALUATION_TYPE>-<ta1name>-[eval|train]-<id>.yaml`
+At runtime, however, the server will look for the filenames as specified by the `*_FILENAMES` configuration variables.
 
 Please note:
 1. `EVALUATION_TYPE` is the value of the configuration variable defined in `config.ini`;
-2. `ta1name` is either `soartech` or `adept`;
+2. `ta1name` is one of the values from the `ALL_TA1_NAMES` configuration variable;
 3. Use `eval` for evaluation scenarios and `train` for training scenarios; and
 4. The `id` should be derived from the scenario ID in the YAML file, although it isn't required, e.g., `qol`, `MJ2`, `urban`, etc.
 
@@ -86,10 +87,12 @@ usage: python -m swagger_server [-h] [-t] [-c CONFIG_GROUP] [-p PORT]
 options:
   -h, --help            show this help message and exit
   -c CONFIG_GROUP, --config_group CONFIG_GROUP
-                        Specify the configuration group in `config.ini` used to launch the Swagger server (default = DEFAULT)
-  -p PORT, --port PORT  Specify the port the Swagger server will listen on (default = 8080)
-  -t, --testing         Put the server in test mode which will run standalone and not connect to TA1.
-```
+                               Specify the configuration group in `config.ini` used to launch the Swagger server (default = DEFAULT)
+  -p PORT, --port PORT         Specify the port the Swagger server will listen on (default = 8080)
+  -t, --testing                Put the server in test mode which will run standalone and not connect to TA1.
+  --max_sessions MAX_SESSIONS  Hard maximum for number of simultaneous active sessions (default 100)
+  --timeout SESSION_TIMEOUT    Number of minutes an ADM can be inactive before it's subject to being recycled (default 60)
+  ```
 
 You can browse the API at:
 
@@ -122,7 +125,7 @@ docker run -p 8080:8080 swagger_server
 ```
 
 ### Running with docker on separate instances
-To run with TA1 on multiple systems set docker env vars for ADM host, Soartech Host, and ADEPT Host.
+To run with TA1 on multiple systems set docker env vars for ADM host.
 ```bash
 docker run -d -p 8080:8080 --name itm-server itm-server
 ```

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -21,6 +21,8 @@ def main(args):
 
     builtins.config_group = args.config_group
     builtins.testing = args.testing
+    builtins.max_sessions = args.max_sessions
+    builtins.session_timeout = args.session_timeout
 
     app = connexion.App(__name__, specification_dir='../swagger/')
     app.app.json_encoder = encoder.JSONEncoder
@@ -30,18 +32,27 @@ def main(args):
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser(description='Run the TA3 evaluation server', usage='python -m swagger_server [-h] [-c CONFIG_GROUP] [-p PORT] [-t]')
+    parser = argparse.ArgumentParser(description='Run the TA3 evaluation server',
+        usage='python -m swagger_server [-h] [-c CONFIG_GROUP] [-p PORT] [-t] [--max_sessions MAX_SESSIONS] [--timeout SESSION_TIMEOUT]')
     parser.add_argument('-c', '--config_group', dest='config_group', type=str, default="DEFAULT",  help='Specify the configuration group in config.ini used to launch the Swagger server (default = DEFAULT)')
     parser.add_argument('-p', '--port', dest='port', type=int, default=None,  help='Specify the port the Swagger server will listen on (default = 8080)')
     parser.add_argument('-t', '--testing', action='store_true', default=False,
                         help='Put the server in test mode which will run standalone and not connect to TA1.')
+    parser.add_argument('--max_sessions', dest='max_sessions', type=int, default=100, help='Hard maximum for number of simultaneous active sessions (default 100)')
+    parser.add_argument('--timeout', dest='session_timeout', type=int, default=60, help="Number of minutes an ADM can be inactive before it's subject to being recycled (default 60)")
     args = parser.parse_args()
 
     #Checking for config_group in config.ini
     config_util.check_ini()
     config = config_util.read_ini()[0]
     if args.config_group not in config:
-        print("The Config Group `" + args.config_group + "` does not exist in config.ini.")
+        print(f"The Config Group `{args.config_group}` does not exist in config.ini.")
+        sys.exit()
+    if args.max_sessions < 1:
+        print(f"The maximum number of sessions must be at least 1.")
+        sys.exit()
+    if args.session_timeout < 1:
+        print(f"The session timeout must be at least 1 minute.")
         sys.exit()
 
     print("Swagger server launching with the `" + args.config_group + "` group (from config.ini)")

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -404,7 +404,7 @@ class ITMSession:
             return 'Exception getting next scenario; ending session.', 503
 
     def _end_session(self) -> Scenario:
-        self.__init__()
+        self.session_complete = True
         return Scenario(session_complete=True, id='', name='',
                         scenes=None, state=None)
 
@@ -434,15 +434,8 @@ class ITMSession:
                 400
             )
 
-        # Re-use current session for same ADM after a client crash
         if self.session_id is None:
             self.session_id = str(uuid.uuid4())
-        elif self.adm_name == adm_name:
-            logging.info("Re-using session %s for ADM %s", self.session_id, self.adm_name)
-            self.history.add_history(
-                "Abort Session", {"session_id": self.session_id, "adm_name": self.adm_name, "domain": self.domain}, None)
-            self.__init__()
-            self.session_id = str(uuid.uuid4()) # but assign new session_id for clarity in logs/history
         else:
             return 'System Overload', 503 # itm_ta2_eval_controller should prevent this
 


### PR DESCRIPTION
See [ticket](https://nextcentury.atlassian.net/browse/ITM-488).

- Support multiple simultaneous sessions with the same adm_name.
   - Use the `session_id` as the “key” and don’t reuse sessions with the same `adm_name` like it used to.
- When the hard cap of active sessions is reached, clear out and re-use a completed session (one that has completed normally)
  - If there are no completed sessions, then clear out and re-use a session that has timed out.
- Externalize session hard cap and session timeout via command-line parameters (with defaults).

To test, launch the server in test mode and set a low hard cap and session timeout, e.g.:
- `python -m swagger_server -t --timeout 1 --max_sessions 1`

Then in the `development` client, add a `sleep(20)` where it changes scenes (e.g., around line 245).

Test the following:
- The server functions normally with the specified number of simultaneous sessions (e.g., `max_sessions`).
- Completed and inactive sessions are reclaimed/recycled as necessary, which the server logs.
- The client gets a 503 "Server Overload" message if a new session is requested but the the max sessions is exceeded and no session can be reclaimed/recycled.
- If a client session times out (i.e., doesn't make a call within `timeout` minutes), it is reclaimed by the server if the max sessions is exceeded.  If the client then makes a call, it should get a 400 "Invalid Session ID" message.
- You can run different sessions with the same `adm_name`.
- The server honors command-line hard caps and session timeouts, but defaults as advertized.
- Anything else you can think of.

**NOTE**: the drawback to this approach (and the reason that a session with the same `adm_name` used to be recycled) is that if you run a bunch of ADM tests create sessions but then fail quickly, you can quickly reach the session maximum and will have to wait for them to start timing out before you can start a session.  We may create an "abort session" API call which a well-behaved client can send if there's a crash/problem (other than a network problem).