### PR TITLE
ITM-974: Expanded/improved history logging.

### DIFF
--- a/swagger_server/itm/itm_action_handler.py
+++ b/swagger_server/itm/itm_action_handler.py
@@ -145,7 +145,8 @@ class ITMActionHandler:
         character = next((character for character in self.session.state.characters \
                          if character.id == action.character_id), None)
 
-        parameters = {"action_type": action.action_type, "session_id": self.session.session_id}
+        parameters = {"action_type": action.action_type, "action_id": action.action_id,
+                      "justification": action.justification, "session_id": self.session.session_id}
         if character:
             parameters['character'] = action.character_id
         match action.action_type:
@@ -175,6 +176,8 @@ class ITMActionHandler:
         if character:
             parameters['character'] = action.character_id
         parameters['action_type'] = action.action_type
+        parameters['action_id'] = action.action_id
+        parameters['justification'] = action.justification
         parameters['session_id'] = self.session.session_id
 
 

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -2,7 +2,6 @@ import boto3
 import json
 import logging
 import os
-import datetime
 import builtins
 
 from typing import Union

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -34,6 +34,8 @@ class ITMHistory:
             self.evaluation_info.pop('scenario_id')
             self.evaluation_info.pop('alignment_target_id')
             self.evaluation_info.pop('adm_name')
+            self.evaluation_info.pop('adm_profile')
+            self.evaluation_info.pop('domain')
             self.evaluation_info.pop('ta1_name')
             self.evaluation_info.pop('ta3_session_id')
         if self.results.get('alignment_score'): # Did user set results?
@@ -41,11 +43,13 @@ class ITMHistory:
             self.results.pop('alignment_score')
             self.results.pop('kdmas')
 
-    def set_metadata(self, scenario_name, scenario_id, alignment_target_id, adm_name, ta1_name, ta3_session_id):
+    def set_metadata(self, scenario_name, scenario_id, alignment_target_id, adm_name, adm_profile, domain, ta1_name, ta3_session_id):
         self.evaluation_info['scenario_name'] = scenario_name
         self.evaluation_info['scenario_id'] = scenario_id
         self.evaluation_info['alignment_target_id'] = alignment_target_id
         self.evaluation_info['adm_name'] = adm_name
+        self.evaluation_info['adm_profile'] = adm_profile
+        self.evaluation_info['domain'] = domain
         self.evaluation_info['ta1_name'] = ta1_name
         self.evaluation_info['ta3_session_id'] = ta3_session_id
 

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -20,38 +20,20 @@ class ITMHistory:
         self.history = []
         self.filepath = config[config_group]["HISTORY_DIRECTORY"] + os.sep
         self.save_history_bucket = config["DEFAULT"]["HISTORY_S3_BUCKET"]
-        self.evaluation_info = {
-            "evalName": config[config_group]['EVAL_NAME'], 
-            "evalNumber": config[config_group]['EVAL_NUMBER'], 
-            "created" : str(datetime.datetime.now())
-        }
-        self.results = {}
+        self.eval_name = config[config_group]['EVAL_NAME']
+        self.eval_number = config[config_group]['EVAL_NUMBER']
+        self.clear_history()
 
     def clear_history(self):
         self.history.clear()
-        if self.evaluation_info.get('scenario_name'): # Did user set metadata?
-            self.evaluation_info.pop('scenario_name')
-            self.evaluation_info.pop('scenario_id')
-            self.evaluation_info.pop('alignment_target_id')
-            self.evaluation_info.pop('adm_name')
-            self.evaluation_info.pop('adm_profile')
-            self.evaluation_info.pop('domain')
-            self.evaluation_info.pop('ta1_name')
-            self.evaluation_info.pop('ta3_session_id')
-        if self.results.get('alignment_score'): # Did user set results?
-            self.results.pop('ta1_session_id')
-            self.results.pop('alignment_score')
-            self.results.pop('kdmas')
+        self.evaluation_info = {
+            "evalName": self.eval_name,
+            "evalNumber": self.eval_number
+        }
+        self.results = {}
 
-    def set_metadata(self, scenario_name, scenario_id, alignment_target_id, adm_name, adm_profile, domain, ta1_name, ta3_session_id):
-        self.evaluation_info['scenario_name'] = scenario_name
-        self.evaluation_info['scenario_id'] = scenario_id
-        self.evaluation_info['alignment_target_id'] = alignment_target_id
-        self.evaluation_info['adm_name'] = adm_name
-        self.evaluation_info['adm_profile'] = adm_profile
-        self.evaluation_info['domain'] = domain
-        self.evaluation_info['ta1_name'] = ta1_name
-        self.evaluation_info['ta3_session_id'] = ta3_session_id
+    def set_metadata(self, metadata: dict):
+        self.evaluation_info.update(metadata)
 
     def set_results(self, ta1_session_id, alignment_score, kdmas):
         self.results['ta1_session_id'] = ta1_session_id

--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -29,6 +29,7 @@ class ITMScenario:
         self.isd: ITMScenarioData
         self.id=''
         self.name=''
+        self.start_time = None
 
     @staticmethod
     def clear_hidden_data(state: State):

--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -76,11 +76,12 @@ class ITMScenario:
         return filtered_actions
 
 
-    def respond_to_probe(self, probe_id, choice_id, justification):
+    def respond_to_probe(self, action_id, probe_id, choice_id, justification):
         """
         Respond to the specified probe with the specified choice and justification
 
         Args:
+            action_id: The id of the action as configured by TA1
             probe_id: The TA1 id of the probe
             choice_id: The TA1 id of the choice the ADM made
             justification: the choice justification provided by the ADM, if any
@@ -95,7 +96,7 @@ class ITMScenario:
         self.session.history.add_history(
             "Respond to TA1 Probe",
             {"session_id": self.session.session_id, "scenario_id": response.scenario_id, "probe_id": response.probe_id,
-             "choice": response.choice, "justification": response.justification},
+             "choice": response.choice, "action_id": action_id, "justification": response.justification},
              None
             )
         if self.ta1_controller:

--- a/swagger_server/itm/itm_scene.py
+++ b/swagger_server/itm/itm_scene.py
@@ -179,7 +179,7 @@ class ITMScene:
                 next_scene_id = mapping.next_scene
                 # Respond to probes if conditions are met.
                 if self._conditions_met(mapping.probe_conditions, session_state, mapping.probe_condition_semantics):
-                    self.parent_scenario.respond_to_probe(mapping.probe_id, mapping.choice, action.justification)
+                    self.parent_scenario.respond_to_probe(mapping.action_id, mapping.probe_id, mapping.choice, action.justification)
                 break  # action_id's are unique within a scene
 
         if not found_mapping: # Handle ADMs ordering something not on the menu

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -756,4 +756,4 @@ class ITMSession:
         if successful:
             return 'valid intention' if body.intent_action else 'valid action'
         else:
-            return f"Error code {code}: {message}"
+            return f"Error code {code}: {message}", code

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -4,7 +4,7 @@ import random
 import os
 import logging
 import builtins
-from datetime import datetime
+import datetime
 from typing import List
 from copy import deepcopy
 from json import dumps
@@ -149,7 +149,7 @@ class ITMSession:
         """
         self.history.add_history(
             "Scenario ended", {"scenario_id": self.itm_scenario.id, "session_id": self.session_id,
-                            "elapsed_time": self.state.elapsed_time}, None)
+                            "end_time": str(datetime.datetime.now()), "simulated_elapsed_time": self.state.elapsed_time}, None)
         logging.info("Scenario %s ended.", self.itm_scenario.id)
         self.state.scenario_complete = True
 
@@ -198,6 +198,8 @@ class ITMSession:
             scenario_id=self.itm_scenario.id,
             alignment_target_id=self.itm_scenario.alignment_target.id,
             adm_name=self.adm_name,
+            adm_profile=self.adm_profile,
+            domain=self.domain,
             ta1_name=self.itm_scenario.ta1_name,
             ta3_session_id=self.session_id,
             )
@@ -209,7 +211,7 @@ class ITMSession:
         if self.save_history:
             kdma = self.itm_scenario.alignment_target.kdma_values[0].kdma.split(" ")[0].lower()
             alignment_type = kdma + "-" + self.itm_scenario.alignment_target.id
-            timestamp = f"{datetime.now():%Y%m%d-%H.%M.%S}" # e.g., 20240821-18.22.53
+            timestamp = f"{datetime.datetime.now():%Y%m%d-%H.%M.%S}" # e.g., 20240821-18.22.53
             filename = f"{self.adm_profile.replace(' ','-')}-" if self.adm_profile else ''
             filename += f"{ITMSession.EVALUATION_TYPE.replace(' ','')}-{self.itm_scenario.id.replace(' ', '_')}-{self.itm_scenario.ta1_name}-{alignment_type.replace(' ', '_')}-{self.adm_name}-{timestamp}"
             self.history.write_to_json_file(filename, self.save_history_to_s3)
@@ -365,8 +367,8 @@ class ITMSession:
             self.current_scenario_index += 1
             self.history.add_history(
                 "Start Scenario",
-                {"session_id": self.session_id, "adm_name": self.adm_name, "adm_profile": self.adm_profile},
-                scenario.to_dict())
+                {"session_id": self.session_id, "adm_name": self.adm_name, "adm_profile": self.adm_profile,
+                 "domain": self.domain, "start_time": str(datetime.datetime.now())}, scenario.to_dict())
             logging.info("Scenario %s starting.", self.itm_scenario.id)
 
             if self.ta1_integration:

--- a/swagger_server/itm/ta1/itm_ta1_controller.py
+++ b/swagger_server/itm/ta1/itm_ta1_controller.py
@@ -4,6 +4,7 @@ import urllib
 import builtins
 from abc import ABC, abstractmethod
 from importlib import import_module
+from math import isnan
 from swagger_server.models import (
     ProbeResponse, AlignmentResults, AlignmentTarget
 )
@@ -132,7 +133,6 @@ class ITMTa1Controller(ABC):
         body = {"session_id": self.session_id, "response": probe_response.to_dict()}
         url = f"{self.url}/api/v1/response"
         self.to_dict(requests.post(url, json=body))
-        return None
 
     def get_probe_response_alignment(self, scenario_id, probe_id):
         base_url = f"{self.url}/api/v1/alignment/probe"
@@ -168,5 +168,12 @@ class ITMTa1Controller(ABC):
 
         # TA1s represent their kdmas differently.
         alignment_results.kdma_values = self.get_kdmas(response)
+
+        # JSON output doesn't like NaN, so change to None
+        if isnan(alignment_results.score):
+            alignment_results = AlignmentResults(
+                alignment_source=alignment_results.alignment_source,
+                alignment_target_id=alignment_results.alignment_target_id,
+                kdma_values=alignment_results.kdma_values)
 
         return alignment_results


### PR DESCRIPTION
The following changes were made:
- Log `action_id` and `justification` in “Take Action” and “Intend Action” history;
- Log `action_id` in “Respond to TA1 Probe” history;
- Log `start_time` and `domain` in “Start Scenario” history;
- Log `end_time` in “Scenario ended” history while renaming `elapsed_time` to `simulated_elapsed_time`;
- Replicate `start_time` and `end_time` in `metadata` (evaluation) block;
- Log `adm_profile` and `domain` in metadata;
- Log session start time in JSON and session end time and duration in server logging; and
- Better handle `NaN` session alignment score (see [this comment](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/122#issuecomment-2725325213) from an un-merged PR).

Unrelated, this also fixes the return code after validating an invalid action.

To test, run a bunch of session types (connected to TA1 and not) and inspect the JSON output.  Note you'll need to make sure you have `SAVE_HISTORY=True` in `config.ini`.



