### PR TITLE
ITM-1023:  Fixed second 2d scenario action mapping

### DIFF
--- a/swagger_server/itm/domains/p2triage/p2triage_action_handler.py
+++ b/swagger_server/itm/domains/p2triage/p2triage_action_handler.py
@@ -37,7 +37,7 @@ class P2TriageActionHandler(ITMActionHandler):
 
         if action.action_type == ActionTypeEnum.TREAT_PATIENT:
             # Character required
-            if not action.action_id:
+            if not character or not character.id:
                 return False, f'Malformed Action: Missing character_id for {action.action_type}', 400
             if character.unseen and not action.intent_action and action.action_type:
                 return False, f'Cannot perform {action.action_type} action with unseen character `{action.character_id}`', 400

--- a/swagger_server/itm/domains/p2triage/scenario_converter.py
+++ b/swagger_server/itm/domains/p2triage/scenario_converter.py
@@ -120,7 +120,7 @@ def make_mappings(row: dict, acronym: str, training: bool) -> list:
         attribute_base = get_kdma_base(acronym, probe_id)
         kdma_assoc: dict = {'medical': float(row['pb_medical']), attribute_base: float(row[f"pb_{attribute_base}"])}
         mapping['kdma_association'] = kdma_assoc
-    if acronym in ['AF', 'MF']:
+    if acronym in ['AF', 'MF', 'AF-MF']:
         mapping['character_id'] = 'Patient B'
     mappings.append(mapping)
 


### PR DESCRIPTION
Fixes a bug where the second action mapping of multi-kdma scenarios (AF-MF) didn't specify a `character_id`.
Moreover, there was a bug in the resulting error message.

To test, use the converter script to regenerate scenarios and compare to your old ones:
- `python swagger_server/itm/domains/p2triage/scenario_converter.py -o ./itm1023 -i AF MF PS SS`

Compare the new scenarios in `itm1023` to your old scenarios, which are probably in `swagger_server/itm/data/june2025/scenarios`

To test the second bugfix:
- Start the server with `python -m swagger_server -t -c MULTI_KDMA`
- Change line 122 of `itm_minimal_runner.py` to `pass`
- run the client with `python itm_minimal_runner --session adept --name itm1023`

After you're done testing, you may wish to update your installed scenarios (assuming they are in the default location) with:
- `python swagger_server/itm/domains/p2triage/scenario_converter.py -i AF MF PS SS`
- `python swagger_server/itm/domains/p2triage/scenario_converter.py -i -s AF MF PS SS`
- `python swagger_server/itm/domains/p2triage/scenario_converter.py -i -r AF MF PS SS`
- `python swagger_server/itm/domains/p2triage/scenario_converter.py -i -r -s AF MF PS SS`
