### PR TITLE
Dev-to-main for July training update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,20 +74,17 @@ generated
 swagger_server/api
 
 # local history output
-itm_history_output
-wumpus_history_output
-june2025_history_output
+*_history_output
 
 # local config files
-config.ini
-config.triage.ini
-config.p2triage.ini
-config.wumpus.ini
+config*.ini
 
 # local scenarios
 itm_scenarios
 swagger_server/itm/data/phase1
 swagger_server/itm/data/june2025
+swagger_server/itm/data/july2025
+swagger_server/itm/data/phase2
 
 # local csvs
 *.csv

--- a/swagger_server/itm/data/domains/p2triage/config.ini.template
+++ b/swagger_server/itm/data/domains/p2triage/config.ini.template
@@ -3,7 +3,7 @@
 
 [DEFAULT]
 
-EVALUATION_TYPE=june2025
+EVALUATION_TYPE=july2025
 SCENARIO_DIRECTORY=swagger_server/itm/data/%(EVALUATION_TYPE)s/scenarios/
 DEFAULT_DOMAIN=p2triage
 SUPPORTED_DOMAINS=p2triage
@@ -24,28 +24,28 @@ ALL_TA1_NAMES=adept
 HISTORY_DIRECTORY=%(EVALUATION_TYPE)s_history_output
 HISTORY_S3_BUCKET=itm-ui-assets
 
-EVAL_NAME=Phase 2 June 2025 Collaboration
-EVAL_NUMBER=8
+EVAL_NAME=Phase 2 July 2025 Collaboration
+EVAL_NUMBER=9
 
-ADEPT_EVAL_FILENAMES=june2025-adept-eval-MF1.yaml,june2025-adept-eval-MF2.yaml,june2025-adept-eval-MF3.yaml,june2025-adept-eval-MF.yaml,
-    june2025-adept-eval-AF1.yaml,june2025-adept-eval-AF2.yaml,june2025-adept-eval-AF3.yaml,june2025-adept-eval-AF.yaml,
-    june2025-adept-eval-SS1.yaml,june2025-adept-eval-SS2.yaml,june2025-adept-eval-SS3.yaml,june2025-adept-eval-SS.yaml,
-    june2025-adept-eval-PS1.yaml,june2025-adept-eval-PS2.yaml,june2025-adept-eval-PS3.yaml,june2025-adept-eval-PS.yaml
+ADEPT_EVAL_FILENAMES=july2025-adept-eval-MF1.yaml,july2025-adept-eval-MF2.yaml,july2025-adept-eval-MF3.yaml,july2025-adept-eval-MF.yaml,
+    july2025-adept-eval-AF1.yaml,july2025-adept-eval-AF2.yaml,july2025-adept-eval-AF3.yaml,july2025-adept-eval-AF.yaml,
+    july2025-adept-eval-SS1.yaml,july2025-adept-eval-SS2.yaml,july2025-adept-eval-SS3.yaml,july2025-adept-eval-SS.yaml,
+    july2025-adept-eval-PS1.yaml,july2025-adept-eval-PS2.yaml,july2025-adept-eval-PS3.yaml,july2025-adept-eval-PS.yaml
 
-ADEPT_TRAIN_FILENAMES=june2025-adept-train-MF.yaml,
-    june2025-adept-train-AF.yaml,
-    june2025-adept-train-SS.yaml,
-    june2025-adept-train-PS.yaml
+ADEPT_TRAIN_FILENAMES=july2025-adept-train-MF.yaml,
+    july2025-adept-train-AF.yaml,
+    july2025-adept-train-SS.yaml,
+    july2025-adept-train-PS.yaml
 
-ADEPT_EVAL_K1_SCENARIOS=June2025-MF1-eval,June2025-MF2-eval,June2025-MF3-eval,June2025-MF-eval
-ADEPT_EVAL_K2_SCENARIOS=June2025-AF1-eval,June2025-AF2-eval,June2025-AF3-eval,June2025-AF-eval
-ADEPT_EVAL_K3_SCENARIOS=June2025-SS1-eval,June2025-SS2-eval,June2025-SS3-eval,June2025-SS-eval
-ADEPT_EVAL_K4_SCENARIOS=June2025-PS1-eval,June2025-PS2-eval,June2025-PS3-eval,June2025-PS-eval
+ADEPT_EVAL_K1_SCENARIOS=July2025-MF1-eval,July2025-MF2-eval,July2025-MF3-eval,July2025-MF-eval
+ADEPT_EVAL_K2_SCENARIOS=July2025-AF1-eval,July2025-AF2-eval,July2025-AF3-eval,July2025-AF-eval
+ADEPT_EVAL_K3_SCENARIOS=July2025-SS1-eval,July2025-SS2-eval,July2025-SS3-eval,July2025-SS-eval
+ADEPT_EVAL_K4_SCENARIOS=July2025-PS1-eval,July2025-PS2-eval,July2025-PS3-eval,July2025-PS-eval
 
-ADEPT_TRAIN_K1_SCENARIOS=June2025-MF-train
-ADEPT_TRAIN_K2_SCENARIOS=June2025-AF-train
-ADEPT_TRAIN_K3_SCENARIOS=June2025-SS-train
-ADEPT_TRAIN_K4_SCENARIOS=June2025-PS-train
+ADEPT_TRAIN_K1_SCENARIOS=July2025-MF-train
+ADEPT_TRAIN_K2_SCENARIOS=July2025-AF-train
+ADEPT_TRAIN_K3_SCENARIOS=July2025-SS-train
+ADEPT_TRAIN_K4_SCENARIOS=July2025-PS-train
 
 ADEPT_K1_ALIGNMENT_TARGETS=ADEPT-June2025-merit-0.0,
     ADEPT-June2025-merit-0.1,
@@ -95,11 +95,6 @@ ADEPT_K4_ALIGNMENT_TARGETS=ADEPT-June2025-personal_safety-0.0,
     ADEPT-June2025-personal_safety-0.9,
     ADEPT-June2025-personal_safety-1.0
 
-ADEPT_K1_ALIGNMENT_DISTRIBUTION_TARGET=ADEPT-June2025-merit-Population-All
-ADEPT_K2_ALIGNMENT_DISTRIBUTION_TARGET=ADEPT-June2025-affiliation-Population-All
-ADEPT_K3_ALIGNMENT_DISTRIBUTION_TARGET=ADEPT-June2025-search-Population-All
-ADEPT_K4_ALIGNMENT_DISTRIBUTION_TARGET=ADEPT-June2025-personal_safety-Population-All
-
 # All of these keywords must be present in the DEFAULT configuration
 REQUIRED_CONFIG=EVALUATION_TYPE, SCENARIO_DIRECTORY, ADEPT_URL, SAVE_HISTORY, SAVE_HISTORY_TO_S3,
   ALL_TA1_NAMES, HISTORY_DIRECTORY, HISTORY_S3_BUCKET, EVAL_NAME, EVAL_NUMBER, ADEPT_EVAL_K1_SCENARIOS,
@@ -110,46 +105,46 @@ REQUIRED_CONFIG=EVALUATION_TYPE, SCENARIO_DIRECTORY, ADEPT_URL, SAVE_HISTORY, SA
 
 [GROUP_TARGET]
 
-ADEPT_K1_ALIGNMENT_TARGETS=ADEPT-June2025-merit-Group-Low,
-    ADEPT-June2025-merit-Group-High
+ADEPT_K1_ALIGNMENT_TARGETS=ADEPT-July2025-merit-Group-Low,
+    ADEPT-July2025-merit-Group-High
 
-ADEPT_K2_ALIGNMENT_TARGETS=ADEPT-June2025-affiliation-Group-Low,
-    ADEPT-June2025-affiliation-Group-High
+ADEPT_K2_ALIGNMENT_TARGETS=ADEPT-July2025-affiliation-Group-Low,
+    ADEPT-July2025-affiliation-Group-High
 
-ADEPT_K3_ALIGNMENT_TARGETS=ADEPT-June2025-search-Group-Low,
-    ADEPT-June2025-search-Group-High
+ADEPT_K3_ALIGNMENT_TARGETS=ADEPT-July2025-search-Group-Low,
+    ADEPT-July2025-search-Group-High
 
-ADEPT_K4_ALIGNMENT_TARGETS=ADEPT-June2025-personal_safety-Group-Low,
-    ADEPT-June2025-personal_safety-Group-High
+ADEPT_K4_ALIGNMENT_TARGETS=ADEPT-July2025-personal_safety-Group-Low,
+    ADEPT-July2025-personal_safety-Group-High
 
 [SUBSET_ONLY]
 
-ADEPT_EVAL_FILENAMES=june2025-adept-eval-MF1.yaml,june2025-adept-eval-MF2.yaml,june2025-adept-eval-MF3.yaml,
-    june2025-adept-eval-AF1.yaml,june2025-adept-eval-AF2.yaml,june2025-adept-eval-AF3.yaml,
-    june2025-adept-eval-SS1.yaml,june2025-adept-eval-SS2.yaml,june2025-adept-eval-SS3.yaml,
-    june2025-adept-eval-PS1.yaml,june2025-adept-eval-PS2.yaml,june2025-adept-eval-PS3.yaml
+ADEPT_EVAL_FILENAMES=july2025-adept-eval-MF1.yaml,july2025-adept-eval-MF2.yaml,july2025-adept-eval-MF3.yaml,
+    july2025-adept-eval-AF1.yaml,july2025-adept-eval-AF2.yaml,july2025-adept-eval-AF3.yaml,
+    july2025-adept-eval-SS1.yaml,july2025-adept-eval-SS2.yaml,july2025-adept-eval-SS3.yaml,
+    july2025-adept-eval-PS1.yaml,july2025-adept-eval-PS2.yaml,july2025-adept-eval-PS3.yaml
 
-ADEPT_EVAL_K1_SCENARIOS=June2025-MF1-eval,June2025-MF2-eval,June2025-MF3-eval
-ADEPT_EVAL_K2_SCENARIOS=June2025-AF1-eval,June2025-AF2-eval,June2025-AF3-eval
-ADEPT_EVAL_K3_SCENARIOS=June2025-SS1-eval,June2025-SS2-eval,June2025-SS3-eval
-ADEPT_EVAL_K4_SCENARIOS=June2025-PS1-eval,June2025-PS2-eval,June2025-PS3-eval
+ADEPT_EVAL_K1_SCENARIOS=July2025-MF1-eval,July2025-MF2-eval,July2025-MF3-eval
+ADEPT_EVAL_K2_SCENARIOS=July2025-AF1-eval,July2025-AF2-eval,July2025-AF3-eval
+ADEPT_EVAL_K3_SCENARIOS=July2025-SS1-eval,July2025-SS2-eval,July2025-SS3-eval
+ADEPT_EVAL_K4_SCENARIOS=July2025-PS1-eval,July2025-PS2-eval,July2025-PS3-eval
 
 [FULL_NO_SUBSET]
 
-ADEPT_EVAL_FILENAMES=june2025-adept-eval-MF.yaml,june2025-adept-eval-AF.yaml,june2025-adept-eval-SS.yaml,june2025-adept-eval-PS.yaml
+ADEPT_EVAL_FILENAMES=july2025-adept-eval-MF.yaml,july2025-adept-eval-AF.yaml,july2025-adept-eval-SS.yaml,july2025-adept-eval-PS.yaml
 
-ADEPT_EVAL_K1_SCENARIOS=June2025-MF-eval
-ADEPT_EVAL_K2_SCENARIOS=June2025-AF-eval
-ADEPT_EVAL_K3_SCENARIOS=June2025-SS-eval
-ADEPT_EVAL_K4_SCENARIOS=June2025-PS-eval
+ADEPT_EVAL_K1_SCENARIOS=July2025-MF-eval
+ADEPT_EVAL_K2_SCENARIOS=July2025-AF-eval
+ADEPT_EVAL_K3_SCENARIOS=July2025-SS-eval
+ADEPT_EVAL_K4_SCENARIOS=July2025-PS-eval
 
 [MULTI_KDMA]
 
-ADEPT_EVAL_FILENAMES=june2025-adept-eval-AF-MF1.yaml,june2025-adept-eval-AF-MF2.yaml,june2025-adept-eval-AF-MF3.yaml,june2025-adept-eval-AF-MF.yaml
-ADEPT_TRAIN_FILENAMES=june2025-adept-train-AF-MF.yaml
+ADEPT_EVAL_FILENAMES=july2025-adept-eval-AF-MF1.yaml,july2025-adept-eval-AF-MF2.yaml,july2025-adept-eval-AF-MF3.yaml,july2025-adept-eval-AF-MF.yaml
+ADEPT_TRAIN_FILENAMES=july2025-adept-train-AF-MF.yaml
 
-ADEPT_EVAL_M1_SCENARIOS=June2025-AF-MF1-eval,June2025-AF-MF2-eval,June2025-AF-MF3-eval,June2025-AF-MF-eval
-ADEPT_TRAIN_M1_SCENARIOS=June2025-AF-MF-train
+ADEPT_EVAL_M1_SCENARIOS=July2025-AF-MF1-eval,July2025-AF-MF2-eval,July2025-AF-MF3-eval,July2025-AF-MF-eval
+ADEPT_TRAIN_M1_SCENARIOS=July2025-AF-MF-train
 
 ADEPT_M1_ALIGNMENT_TARGETS=ADEPT-June2025-affiliation_merit-0.0_0.0,
     ADEPT-June2025-affiliation_merit-0.0_1.0,
@@ -160,11 +155,11 @@ REQUIRED_CONFIG=ADEPT_EVAL_M1_SCENARIOS, ADEPT_TRAIN_M1_SCENARIOS, ADEPT_M1_ALIG
 
 [MULTI_KDMA_SUBSET]
 
-ADEPT_EVAL_FILENAMES=june2025-adept-eval-AF-MF1.yaml,june2025-adept-eval-AF-MF2.yaml,june2025-adept-eval-AF-MF3.yaml
-ADEPT_TRAIN_FILENAMES=june2025-adept-train-AF-MF.yaml
+ADEPT_EVAL_FILENAMES=july2025-adept-eval-AF-MF1.yaml,july2025-adept-eval-AF-MF2.yaml,july2025-adept-eval-AF-MF3.yaml
+ADEPT_TRAIN_FILENAMES=july2025-adept-train-AF-MF.yaml
 
-ADEPT_EVAL_M1_SCENARIOS=June2025-AF-MF1-eval,June2025-AF-MF2-eval,June2025-AF-MF3-eval
-ADEPT_TRAIN_M1_SCENARIOS=June2025-AF-MF-train
+ADEPT_EVAL_M1_SCENARIOS=July2025-AF-MF1-eval,July2025-AF-MF2-eval,July2025-AF-MF3-eval
+ADEPT_TRAIN_M1_SCENARIOS=July2025-AF-MF-train
 
 ADEPT_M1_ALIGNMENT_TARGETS=ADEPT-June2025-affiliation_merit-0.0_0.0,
     ADEPT-June2025-affiliation_merit-0.0_1.0,
@@ -175,11 +170,11 @@ REQUIRED_CONFIG=ADEPT_EVAL_M1_SCENARIOS, ADEPT_TRAIN_M1_SCENARIOS, ADEPT_M1_ALIG
 
 [MULTI_KDMA_FULL_NO_SUBSET]
 
-ADEPT_EVAL_FILENAMES=june2025-adept-eval-AF-MF.yaml
-ADEPT_TRAIN_FILENAMES=june2025-adept-train-AF-MF.yaml
+ADEPT_EVAL_FILENAMES=july2025-adept-eval-AF-MF.yaml
+ADEPT_TRAIN_FILENAMES=july2025-adept-train-AF-MF.yaml
 
-ADEPT_EVAL_M1_SCENARIOS=June2025-AF-MF-eval
-ADEPT_TRAIN_M1_SCENARIOS=June2025-AF-MF-train
+ADEPT_EVAL_M1_SCENARIOS=July2025-AF-MF-eval
+ADEPT_TRAIN_M1_SCENARIOS=July2025-AF-MF-train
 
 ADEPT_M1_ALIGNMENT_TARGETS=ADEPT-June2025-affiliation_merit-0.0_0.0,
     ADEPT-June2025-affiliation_merit-0.0_1.0,

--- a/swagger_server/itm/domains/p2triage/csv_preprocessor.py
+++ b/swagger_server/itm/domains/p2triage/csv_preprocessor.py
@@ -1,15 +1,14 @@
 import csv
 
-EVALUATION_NAME = 'June2025'
+EVALUATION_NAME = 'July2025'
 WRITE_FILES = True
 IGNORED_LIST = []
-#IGNORED_LIST = ['MF', 'AF', 'SS', 'PS']
 
 kdmas_info: list[dict] = [
-    {'acronym': 'MF', 'full_name': 'Merit Focus', 'filename': 'June2025MeritFocus'},
-    {'acronym': 'AF', 'full_name': 'Affiliation Focus', 'filename': 'June2025AffiliationFocus'},
-    {'acronym': 'SS', 'full_name': 'Search vs Stay', 'filename': 'June2025SearchStay'},
-    {'acronym': 'PS', 'full_name': 'Personal Safety Focus', 'filename': 'June2025PersonalSafety'}
+    {'acronym': 'MF', 'full_name': 'Merit Focus', 'filename': f'{EVALUATION_NAME}MeritFocus'},
+    {'acronym': 'AF', 'full_name': 'Affiliation Focus', 'filename': f'{EVALUATION_NAME}AffiliationFocus'},
+    {'acronym': 'SS', 'full_name': 'Search vs Stay', 'filename': f'{EVALUATION_NAME}SearchStay'},
+    {'acronym': 'PS', 'full_name': 'Personal Safety Focus', 'filename': f'{EVALUATION_NAME}PersonalSafety'}
     ]
 
 expected_fields = ['scenario_id', 'scenario_name', 'probe_id', 'intro_text', 'probe_full_text', 'probe_question',
@@ -19,12 +18,12 @@ expected_fields = ['scenario_id', 'scenario_name', 'probe_id', 'intro_text', 'pr
 
 # Each inner list is the set of probes to include in a given scenario.
 assessment_sets: dict = {
-    'MF': [['21', '24', '12', '16',  '5', '10'],
-           ['32', '35', '27', '48', '20',  '9'],
-           ['33', '41', '40', '54', '58', '71']],
-    'AF': [['18', '17', '14', '10',  '4',  '1'],
-           ['24', '22', '35', '33', '44', '37'],
-           ['52', '53', '42', '54', '45', '43']],
+    'MF': [['21', '24', '25', '39', '16', '58'],
+           ['32', '35', '37',  '1', '48', '20'],
+           ['33', '41', '42', '40', '54',  '5']],
+    'AF': [['18', '17', '12', '14', '10',  '4'],
+           ['24', '22', '16', '29', '33', '44'],
+           ['52', '53', '47', '42', '54', '45']],
     'SS': [[ '2', '14',  '3', '40', '43', '42'],
            [ '5', '17',  '9', '44', '36', '45'],
            [ '8', '20', '13', '46', '30', '48']],

--- a/swagger_server/itm/domains/p2triage/p2triage_action_handler.py
+++ b/swagger_server/itm/domains/p2triage/p2triage_action_handler.py
@@ -37,7 +37,7 @@ class P2TriageActionHandler(ITMActionHandler):
 
         if action.action_type == ActionTypeEnum.TREAT_PATIENT:
             # Character required
-            if not action.action_id:
+            if not character or not character.id:
                 return False, f'Malformed Action: Missing character_id for {action.action_type}', 400
             if character.unseen and not action.intent_action and action.action_type:
                 return False, f'Cannot perform {action.action_type} action with unseen character `{action.character_id}`', 400

--- a/swagger_server/itm/domains/p2triage/scenario_converter.py
+++ b/swagger_server/itm/domains/p2triage/scenario_converter.py
@@ -4,7 +4,7 @@ import os
 import argparse
 
 # These are constants that cannot be overridden via the command line
-EVALUATION_NAME = 'June2025'
+EVALUATION_NAME = 'July2025'
 TA1_NAME = 'adept'
 
 # These are default values that can be overridden via the command line
@@ -16,11 +16,11 @@ OUT_PATH = f"swagger_server/itm/data/{EVALUATION_NAME.lower()}/scenarios"
 IGNORED_LIST = []
 
 kdmas_info: list[dict] = [
-    {'acronym': 'MF', 'full_name': 'Merit Focus', 'filename': 'June2025MeritFocus'},
-    {'acronym': 'AF', 'full_name': 'Affiliation Focus', 'filename': 'June2025AffiliationFocus'},
-    {'acronym': 'SS', 'full_name': 'Search vs Stay', 'filename': 'June2025SearchStay'},
-    {'acronym': 'PS', 'full_name': 'Personal Safety Focus', 'filename': 'June2025PersonalSafety'},
-    {'acronym': 'AF-MF', 'full_name': 'Affiliation Focus Set', 'filename': 'June2025-AF-MF'}
+    {'acronym': 'MF', 'full_name': 'Merit Focus', 'filename': f'{EVALUATION_NAME}MeritFocus'},
+    {'acronym': 'AF', 'full_name': 'Affiliation Focus', 'filename': f'{EVALUATION_NAME}AffiliationFocus'},
+    {'acronym': 'SS', 'full_name': 'Search vs Stay', 'filename': f'{EVALUATION_NAME}SearchStay'},
+    {'acronym': 'PS', 'full_name': 'Personal Safety Focus', 'filename': f'{EVALUATION_NAME}PersonalSafety'},
+    {'acronym': 'AF-MF', 'full_name': 'Affiliation Focus Set', 'filename': f'{EVALUATION_NAME}-AF-MF'}
     ]
 
 expected_fields = ['scenario_id', 'scenario_name', 'probe_id', 'intro_text', 'probe_full_text', 'probe_question',

--- a/swagger_server/itm/domains/p2triage/scenario_converter.py
+++ b/swagger_server/itm/domains/p2triage/scenario_converter.py
@@ -58,7 +58,7 @@ def make_state(row: dict, acronym: str, training: str, first_row: str = False) -
         character.update({'medical_condition': float(row['pa_medical'])})
         character.update({'attribute_rating': float(row[f"pa_{attribute_base}"])})
     character_list.append(character)
-    if 'saftey' not in attribute_base:
+    if 'safety' not in attribute_base:
         character = {'id': 'Patient B', 'name': 'Patient B', 'unstructured': row['patient_b_text']}
         if training or not REDACT_EVAL:
             character.update({'medical_condition': float(row['pb_medical'])})
@@ -120,7 +120,7 @@ def make_mappings(row: dict, acronym: str, training: bool) -> list:
         attribute_base = get_kdma_base(acronym, probe_id)
         kdma_assoc: dict = {'medical': float(row['pb_medical']), attribute_base: float(row[f"pb_{attribute_base}"])}
         mapping['kdma_association'] = kdma_assoc
-    if acronym in ['AF', 'MF']:
+    if acronym in ['AF', 'MF', 'AF-MF']:
         mapping['character_id'] = 'Patient B'
     mappings.append(mapping)
 

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -450,6 +450,8 @@ class ITMSession:
         self.kdma_training = kdma_training
         self.adm_name = adm_name
         self.adm_profile = adm_profile if adm_profile else ''
+        if 'testrun' in self.adm_name or 'test' in self.adm_profile:
+            self.save_history_to_s3 = False
         if max_scenarios == 0:
             max_scenarios = None
         self.itm_scenarios = []


### PR DESCRIPTION
This code is identical to the recently merged [ITM-1053](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/140).

For a sanity check, though, be sure you can exercise the 1d training scenarios:
- `python -m swagger_server`
- `python itm_minimal_runner --session adept --training full --name train1d`


[ITM-1053]: https://nextcentury.atlassian.net/browse/ITM-1053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ