### PR TITLE
ITM-1301: Improve server logging to facilitate debugging multiple simultaneous connections

### DIFF
--- a/swagger_server/itm/domains/p2triage/scenario_converter.py
+++ b/swagger_server/itm/domains/p2triage/scenario_converter.py
@@ -342,7 +342,7 @@ if __name__ == '__main__':
         VERBOSE = True
     if args.evalname:
         EVALUATION_NAME = args.evalname
-        OUT_PATH.replace(DEFAULT_EVALUATION_NAME, EVALUATION_NAME)
+        OUT_PATH = OUT_PATH.replace(DEFAULT_EVALUATION_NAME, EVALUATION_NAME)
         for kdma_info in kdmas_info:
             kdma_info['filename'] = kdma_info['filename'].replace(DEFAULT_EVALUATION_NAME, EVALUATION_NAME)
     if args.no_output:

--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -110,7 +110,7 @@ class ITMScenario:
             try:
                 self.ta1_controller.post_probe(probe_response=response)
             except exceptions.HTTPError:
-                logging.exception("HTTPError from TA1 posting probe.")
+                logging.exception("%s: HTTPError from TA1 posting probe.", self.session.log_id)
             try:
                 # Get and log probe response alignment if not training and TA1 supports it.
                 if not self.session.kdma_training and self.ta1_controller.supports_probe_alignment():
@@ -135,9 +135,9 @@ class ITMScenario:
                                             self.session.log_id, self.id, alignment_scenario_id)
             except exceptions.HTTPError:
                 # Consider changing to logging.exception when this exception isn't so common.
-                logging.error("HTTPError from TA1 getting probe alignment.")
+                logging.error("%s: HTTPError from TA1 getting probe alignment.", self.session.log_id)
             except:
-                logging.exception("Exception getting probe alignment from TA1.")
+                logging.exception("%s: Exception getting probe alignment from TA1.", self.session.log_id)
         self.probes_sent.append(probe_id)
         self.probe_responses_sent.append(choice_id)
         logging.info("%s: Responding to probe %s from scenario %s with choice %s.",

--- a/swagger_server/itm/itm_scenario.py
+++ b/swagger_server/itm/itm_scenario.py
@@ -119,7 +119,7 @@ class ITMScenario:
                         response.scenario_id,
                         response.probe_id
                     )
-                    logging.info(f"Probe alignment score: {probe_response_alignment.get('score', 'nan')}")
+                    logging.info(f"{self.session.log_id}: Probe alignment score: {probe_response_alignment.get('score', 'nan')}")
                     self.session.history.add_history(
                         "TA1 Probe Response Alignment",
                         {"session_id": self.ta1_controller.session_id,
@@ -131,7 +131,8 @@ class ITMScenario:
                     if probe_response_alignment.get('alignment_source'):
                         alignment_scenario_id = probe_response_alignment['alignment_source'][0]['scenario_id']
                         if self.id != alignment_scenario_id:
-                            logging.warning("\033[92mContamination in probe alignment! scenario is %s but alignment source scenario is %s.\033[00m", self.id, alignment_scenario_id)
+                            logging.warning("\033[92m%sContamination in probe alignment! scenario is %s but alignment source scenario is %s.\033[00m",
+                                            self.session.log_id, self.id, alignment_scenario_id)
             except exceptions.HTTPError:
                 # Consider changing to logging.exception when this exception isn't so common.
                 logging.error("HTTPError from TA1 getting probe alignment.")
@@ -139,8 +140,8 @@ class ITMScenario:
                 logging.exception("Exception getting probe alignment from TA1.")
         self.probes_sent.append(probe_id)
         self.probe_responses_sent.append(choice_id)
-        logging.info("Responding to probe %s from scenario %s with choice %s.",
-                     response.probe_id, response.scenario_id, response.choice)
+        logging.info("%s: Responding to probe %s from scenario %s with choice %s.",
+                     self.session.log_id, response.probe_id, response.scenario_id, response.choice)
 
     def action_taken(self, action: Action):
         pass # Nothing to do at base class level
@@ -161,7 +162,8 @@ class ITMScenario:
                 and self.isd.current_scene.id == next_scene_id - 1:
                 pass # This is expected when scenario ids are simple indices
             else:
-                logging.error("\033[92mScene configuration issue: next scene '%s' not found; ending scenario.\033[00m", next_scene_id)
+                logging.error("\033[92m%sScene configuration issue: next scene '%s' not found; ending scenario.\033[00m",
+                              self.session.log_id, next_scene_id)
             self.isd.current_scene.state = None # Supports single-scenario sessions
             self.end_scenario()
             return
@@ -173,12 +175,12 @@ class ITMScenario:
 
         # If the scene has no action mappings, then the scenario ends.
         if self.isd.current_scene.action_mappings == []:
-            logging.warning("Scene has no action mappings; ending scenario.")
+            logging.warning("%s: Scene has no action mappings; ending scenario.", self.session.log_id)
             self.end_scenario()
             return
 
         # Log the scene change
-        logging.info("Changing to scene ID %s.", self.isd.current_scene.id)
+        logging.info("%s: Changing to scene ID %s.", self.session.log_id, self.isd.current_scene.id)
         self.session.history.add_history(
             "Change scene",
             {"session_id": self.session.session_id,
@@ -229,7 +231,8 @@ class ITMScenario:
                     if character.id in getattr(self.isd.current_scene, 'removed_characters', [])
                 ]
                 if len(filtered_out_characters) > 0:
-                    logging.warning("\033[92mScene configuration issue: target state includes character that was removed\033[00m")
+                    logging.warning("\033[92m%sScene configuration issue: target state includes character that was removed\033[00m",
+                                    self.session.log_id)
 
                 # Replace them with the new versions, plus add new characters.
                 current_state.characters.extend(deepcopy(target_state.characters))

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -63,6 +63,7 @@ class ITMSession:
         Initialize an ITMSession.
         """
         self.session_id = None
+        self.log_id = None
         self.adm_name = ''
         self.adm_profile = ''
         self.time_started = 0
@@ -161,7 +162,7 @@ class ITMSession:
         self.history.add_history(
             "Scenario ended", {"scenario_id": self.itm_scenario.id, "session_id": self.session_id,
                             "end_time": str(scenario_end_time), "simulated_elapsed_time": self.state.elapsed_time}, None)
-        logging.info("Scenario %s ended.", self.itm_scenario.id)
+        logging.info("%s: Scenario %s ended.", self.log_id, self.itm_scenario.id)
         self.state.scenario_complete = True
 
         if self.kdma_training:
@@ -184,15 +185,15 @@ class ITMSession:
                     "target_id": self.itm_scenario.ta1_controller.alignment_target_id},
                     session_alignment.to_dict()
                 )
-                logging.info("Got session alignment score %s from TA1.", session_alignment_score)
+                logging.info("%s: Got session alignment score %s from TA1.", self.log_id, session_alignment_score)
                 kdmas = []
                 for kdma in session_alignment.kdma_values:
                     kdmas.append(kdma.to_dict())
                 if session_alignment.alignment_source:
                     alignment_scenario_id = session_alignment.alignment_source[0].scenario_id
                     if self.itm_scenario.id != alignment_scenario_id:
-                        logging.warning("\033[92mContamination in session_alignment! scenario is %s but alignment source scenario is %s.\033[00m",
-                                        self.itm_scenario.id, alignment_scenario_id)
+                        logging.warning("\033[92m%s: Contamination in session_alignment! scenario is %s but alignment source scenario is %s.\033[00m",
+                                        self.log_id, self.itm_scenario.id, alignment_scenario_id)
             except exceptions.HTTPError:
                 session_alignment_score = 'Error'
                 logging.exception("HTTPError from TA1 getting session alignment.")
@@ -292,7 +293,7 @@ class ITMSession:
             return 'No alignment target in training sessions', 400
 
         if self.session_type == 'eval' and 'base' in self.adm_profile:
-            logging.warning('\033[92mAn ADM with "base" in the ADM profile is requesting an alignment target during evaluation.\033[00m')
+            logging.warning('\033[92mADM %s with "base" in the ADM profile is requesting an alignment target during evaluation.\033[00m', self.adm_name)
 
         self.history.add_history(
             "Get Alignment Target",
@@ -378,7 +379,7 @@ class ITMSession:
                 "Start Scenario",
                 {"session_id": self.session_id, "adm_name": self.adm_name, "adm_profile": self.adm_profile,
                  "domain": self.domain, "start_time": self.itm_scenario.start_time}, scenario.to_dict())
-            logging.info("Scenario %s starting.", self.itm_scenario.id)
+            logging.info("%s: Scenario %s starting.", self.log_id, self.itm_scenario.id)
             scenario.id = self.itm_scenario.adm_id # Redact actual id/name from ADMs
             scenario.name = self.itm_scenario.adm_name
             scenario.alt_id = None
@@ -391,7 +392,7 @@ class ITMSession:
                     self.history.add_history(
                         "TA1 Session ID", {}, ta1_session_id
                     )
-                    logging.info("Got new session_id '%s' from TA1.", ta1_session_id)
+                    logging.info("%s: Got new session_id '%s' from TA1.", self.log_id, ta1_session_id)
                 except exceptions.HTTPError:
                     self._end_session() # Exception here ends the session
                     logging.exception("HTTPError from TA1 starting session.")
@@ -404,7 +405,7 @@ class ITMSession:
             # Get alignment target; was previously obtained from TA1 unless testing.
             if not self.kdma_training:
                 alignment_target = self.itm_scenario.alignment_target
-                logging.info("Using alignment target %s.", alignment_target.id)
+                logging.info("%s: Using alignment target %s.", self.log_id, alignment_target.id)
                 self.history.add_history(
                     "Alignment Target",
                     {"session_id": self.itm_scenario.ta1_controller.session_id if self.ta1_integration else None,
@@ -414,7 +415,7 @@ class ITMSession:
 
             return scenario
         except:
-            logging.exception("Exception getting next scenario; ending session.")
+            logging.exception("%s: Exception getting next scenario; ending session.", self.log_id)
             self._end_session() # Exception here ends the session
             return 'Exception getting next scenario; ending session.', 503
 
@@ -452,6 +453,7 @@ class ITMSession:
 
         if self.session_id is None:
             self.session_id = str(uuid.uuid4())
+            self.log_id = self.session_id.split('-')[-1]
         else:
             return 'System Overload', 503 # itm_ta2_eval_controller should prevent this
 
@@ -574,10 +576,10 @@ class ITMSession:
 
             self.itm_scenarios.extend(ta1_scenarios)
             num_read_scenarios += len(ta1_scenarios)
-            logging.info('Loaded %d scenario(s) for %s.', len(ta1_scenarios), ta1_name)
+            logging.info('%s: Loaded %d scenario(s) for %s.', self.log_id, len(ta1_scenarios), ta1_name)
 
         scenario_ctr = 0
-        logging.info("Scenario load summary:")
+        logging.info("%s: Scenario load summary:", self.log_id)
         for scenario in self.itm_scenarios:
             logging.info(f'  Scenario #{scenario_ctr+1} has ID {scenario.id} and alignment target {scenario.alignment_target.id}.')
             scenario_ctr += 1
@@ -589,7 +591,7 @@ class ITMSession:
                 random_index = random.randint(0, num_read_scenarios - 1)
                 self.itm_scenarios.append(deepcopy(self.itm_scenarios[random_index]))
 
-        logging.info("Loaded %d total scenario(s) from '%s'.", len(self.itm_scenarios), scenario_path)
+        logging.info("%s: Loaded %d total scenario(s) from '%s'.", self.log_id, len(self.itm_scenarios), scenario_path)
         self.current_scenario_index = 0
 
         return self.session_id, 200
@@ -679,7 +681,7 @@ class ITMSession:
             The current state of the scenario as a State object.
         """
 
-        message = f"ADM {'intended' if intent_only else 'chose'} action {adm_action.action_type}"
+        message = f"{self.log_id}: ADM {'intended' if intent_only else 'chose'} action {adm_action.action_type}"
         if adm_action.character_id:
             message += f" with character {adm_action.character_id}"
             if adm_action.parameters:
@@ -719,7 +721,8 @@ class ITMSession:
                 return 'Could not get session alignment; is a TA1 server running?', 503
         else:
             session_alignment = AlignmentResults(alignment_source=[], alignment_target_id=target_id, score=-0.5)
-        logging.info("Got session alignment score %f from TA1 for alignment target id %s.", session_alignment.score, target_id)
+        logging.info("%s: Got session alignment score %f from TA1 for alignment target id %s.",
+                     self.log_id, session_alignment.score, target_id)
         self.history.add_history(
             "Get Session Alignment",
             {"scenario_id": self.itm_scenario.id, "session_id": self.session_id, "target_id": target_id},

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -196,10 +196,10 @@ class ITMSession:
                                         self.log_id, self.itm_scenario.id, alignment_scenario_id)
             except exceptions.HTTPError:
                 session_alignment_score = 'Error'
-                logging.exception("HTTPError from TA1 getting session alignment.")
+                logging.exception("%s: HTTPError from TA1 getting session alignment.", self.log_id)
             except Exception:
                 session_alignment_score = 'Error'
-                logging.exception("Exception getting session alignment. Ignoring.")
+                logging.exception("%s: Exception getting session alignment. Ignoring.", self.log_id)
 
         if (self.session_type != 'test'):
             self.state.unstructured = f'Scenario {self.itm_scenario.adm_id} complete for target {self.itm_scenario.alignment_target.id}. Session alignment score = {session_alignment_score}'
@@ -395,10 +395,10 @@ class ITMSession:
                     logging.info("%s: Got new session_id '%s' from TA1.", self.log_id, ta1_session_id)
                 except exceptions.HTTPError:
                     self._end_session() # Exception here ends the session
-                    logging.exception("HTTPError from TA1 starting session.")
+                    logging.exception("%s: HTTPError from TA1 starting session.", self.log_id)
                     return 'Could not get new session.  Ending session.', 503
                 except:
-                    logging.exception("Exception communicating with TA1; is the TA1 server running?  Ending session.")
+                    logging.exception("%s: Exception communicating with TA1; is the TA1 server running?  Ending session.", self.log_id)
                     self._end_session() # Exception here ends the session
                     return 'Exception communicating with TA1; is the TA1 server running?  Ending session.', 503
 
@@ -511,7 +511,7 @@ class ITMSession:
                 ITMSession.init_ta1_data(ta1_names)
                 ITMSession.alignment_data.clear() # Clear alignment data cache
             except:
-                logging.exception("Exception communicating with TA1; is the TA1 server running?  Ending session.")
+                logging.exception("%s: Exception communicating with TA1; is the TA1 server running?  Ending session.", self.log_id)
                 self._end_session() # Exception here ends the session
                 return 'Exception communicating with TA1; is the TA1 server running?  Ending session.', 503
 
@@ -561,7 +561,8 @@ class ITMSession:
                                         ITMTa1Controller.create_controller(ta1_name, target_id, alignment_target))
                                 scenario_ctr += 1
                             except Exception as e:
-                                logging.fatal(f"Couldn't obtain alignment target '{target_id}'. Check your TA3 server configuration or connection to TA1.")
+                                logging.fatal("%s: Couldn't obtain alignment target '%s'. Check your TA3 server configuration or connection to TA1.",
+                                              self.log_id, target_id)
                                 raise e
                         return scenario_ctr
 
@@ -717,7 +718,7 @@ class ITMSession:
                     session_alignment = AlignmentResults(alignment_source=[], alignment_target_id=target_id, score=-0.5)
 
             except:
-                logging.exception("Exception getting session alignment; is a TA1 server running?")
+                logging.exception("%s: Exception getting session alignment; is a TA1 server running?", self.log_id)
                 return 'Could not get session alignment; is a TA1 server running?', 503
         else:
             session_alignment = AlignmentResults(alignment_source=[], alignment_target_id=target_id, score=-0.5)


### PR DESCRIPTION
For this, I added a `log_id` (the last/right-most hex block from the `session_id`) to most server logging.

To test:
- Clone a temp copy of the client repository, and copy your `config.ini` to this repo.
- Start your TA1 server.
- Start the server with an appropriate server config (e.g., `-c FEB_OPENWORLD`).
- Start both clients simultaneously (or staggered slightly) and ensure that you see the log_id prepended to most server logging.
- Maybe peruse server code and see if there are any instances you think adding this additional logging will help with debugging multiple simultaneous connections.