### PR TITLE
ITM-1411:  Allow client to specify server config

### DIFF
--- a/automated_tester.py
+++ b/automated_tester.py
@@ -507,7 +507,7 @@ def build_server_output_path(branch_name, cfg, group_name):
     return build_output_dir(branch_name) / f"{cfg}_{group_name}_server.txt"
 
 def build_runner_command(client_venv_python, runner_path, phase, training):
-    runner_cmd = [str(client_venv_python), str(runner_path), '--name', 'integration_test', '--session', 'adept', '--profile', 'test']
+    runner_cmd = [str(client_venv_python), str(runner_path), '--name', 'integration_testrun', '--session', 'adept']
     if phase == 1:
         runner_cmd.extend(['--domain', 'triage'])
     if training:

--- a/swagger_server/itm/domains/p2triage/p2triage_scenario.py
+++ b/swagger_server/itm/domains/p2triage/p2triage_scenario.py
@@ -1,4 +1,3 @@
-import builtins
 import logging
 from swagger_server.models import (
     Action,
@@ -15,8 +14,8 @@ class P2triageScenario(ITMScenario):
         super().__init__(yaml_path, session, ta1_name, training)
 
         # Tells the server to get its probe data from characters
-        config = Configuration.get_config()
-        self.inferred_responses = config[builtins.config_group].getboolean("INFERRED_RESPONSES", fallback=False)
+        self.inferred_responses = \
+            Configuration.get_config()[session.config_group].getboolean("INFERRED_RESPONSES", fallback=False)
         self.probe_map: dict[str, dict[str, str]] = None
         self.treatment_order: list = None
         self.character_map: dict = None

--- a/swagger_server/itm/itm_history.py
+++ b/swagger_server/itm/itm_history.py
@@ -2,25 +2,25 @@ import boto3
 import json
 import logging
 import os
-import builtins
 
+from swagger_server.config_util import Configuration
 from typing import Union
 
 class ITMHistory:
     """
     Class for managing ADM action history.
     """
+    config = Configuration.get_config()
 
-    def __init__(self, config):
+    def __init__(self, config_group):
         """
         Initialize an instance of ITMHistory.
         """
-        config_group = builtins.config_group
         self.history = []
-        self.filepath = config[config_group]["HISTORY_DIRECTORY"] + os.sep
-        self.save_history_bucket = config[config_group]["HISTORY_S3_BUCKET"]
-        self.eval_name = config[config_group]['EVAL_NAME']
-        self.eval_number: int = int(config[config_group]['EVAL_NUMBER'])
+        self.filepath = self.config[config_group]["HISTORY_DIRECTORY"] + os.sep
+        self.save_history_bucket = self.config[config_group]["HISTORY_S3_BUCKET"]
+        self.eval_name = self.config[config_group]['EVAL_NAME']
+        self.eval_number: int = int(self.config[config_group]['EVAL_NUMBER'])
         self.clear_history()
 
     def clear_history(self):

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -30,38 +30,28 @@ class ITMSession:
     """
     Class for representing and manipulating a simulation scenario session.
     """
-    config = Configuration.get_config()
-    config_group = builtins.config_group
 
     # Class variables
-    EVALUATION_TYPE = config[config_group]['EVALUATION_TYPE']
-    EVALUATION_NAME = config[config_group]['EVAL_NAME']
-    EVALUATION_NUMBER = int(config[config_group]['EVAL_NUMBER'])
-    DEFAULT_DOMAIN = config[config_group]['DEFAULT_DOMAIN']
-    SUPPORTED_DOMAINS = config[config_group]['SUPPORTED_DOMAINS']
-    SCENARIO_DIRECTORY = config[config_group]['SCENARIO_DIRECTORY']
-    ALL_TA1_NAMES = config[config_group]['ALL_TA1_NAMES'].replace('\n','').split(',')
+    config = Configuration.get_config()
+    initial_config_group = builtins.config_group
+    DEFAULT_DOMAIN = config[initial_config_group]['DEFAULT_DOMAIN']
+    SUPPORTED_DOMAINS = config[initial_config_group]['SUPPORTED_DOMAINS']
+    ALL_TA1_NAMES = config[initial_config_group]['ALL_TA1_NAMES'].replace('\n','').split(',')
 
-    # maps alignment id to list alignment_targets, as limited by configuration; used whether connecting to TA1 or not
-    alignment_data = {}
     # maps ta1_name to list of alignment target IDs obtained from the TA1 server
     alignment_ids = {}
     # This determines whether the server makes calls to TA1
     ta1_integration = not builtins.testing
     # Cache TA1 alignment target ids and alignment targets if true, else query TA1 every session
-    cache_ta1_targets = config[config_group].getboolean("CACHE_TA1_TARGETS", fallback=False)
-    # Don't request session alignment from TA1 at the end of a session
-    calc_alignment = config[config_group].getboolean("CALC_ALIGNMENT", fallback=True)
-    # This determines whether the server saves history to JSON
-    save_history = config[config_group].getboolean("SAVE_HISTORY")
-    # save_history must also be True
-    save_history_to_s3 = config[config_group].getboolean("SAVE_HISTORY_TO_S3")
+    cache_ta1_targets = config[initial_config_group].getboolean("CACHE_TA1_TARGETS", fallback=False)
 
 
     def __init__(self):
         """
         Initialize an ITMSession.
         """
+        self.init_config('DEFAULT')
+
         self.session_id = None
         self.log_id = None
         self.adm_name = ''
@@ -84,9 +74,11 @@ class ITMSession:
         # Action Handler
         self.action_handler: ITMActionHandler = None
         # ADM History
-        self.history: ITMHistory = ITMHistory(ITMSession.config)
+        self.history: ITMHistory = None
         # This determines whether the server returns history in final State after each scenario completes
         self.return_scenario_history = False
+        # maps alignment id to list alignment_targets; used whether connecting to TA1 or not
+        self.alignment_data = {}
 
     def __deepcopy__(self, memo):
         return self # Allows us to deepcopy ITMScenarios
@@ -122,8 +114,23 @@ class ITMSession:
         logging.info("Done.")
 
 
+    def init_config(self, config_group: str):
+        config = ITMSession.config
+        self.SCENARIO_DIRECTORY = config[config_group]['SCENARIO_DIRECTORY']
+        self.EVALUATION_TYPE = config[config_group]['EVALUATION_TYPE']
+        self.EVALUATION_NAME = config[config_group]['EVAL_NAME']
+        self.EVALUATION_NUMBER = int(self.config[config_group]['EVAL_NUMBER'])
+        # Don't request session alignment from TA1 at the end of a session
+        self.calc_alignment = self.config[config_group].getboolean("CALC_ALIGNMENT", fallback=True)
+        # This determines whether the server saves history to JSON
+        self.save_history = self.config[config_group].getboolean("SAVE_HISTORY")
+        # save_history must also be True
+        self.save_history_to_s3 = self.config[config_group].getboolean("SAVE_HISTORY_TO_S3")
+        self.history = ITMHistory(config) # TODO Move to start_session?
+
+
     def load_alignment_target(self, target_id, ta1_name):
-        alignment_target = ITMSession.alignment_data.get(target_id)
+        alignment_target = self.alignment_data.get(target_id)
         if alignment_target: # Previously retrieved specified alignment target
             return alignment_target
         if self.ta1_integration:
@@ -138,7 +145,7 @@ class ITMSession:
                           KDMAValueParametersInner("medical_weight", "single", 0.5),
                           KDMAValueParametersInner("attr_weight", "single", 0.5)]
             alignment_target = AlignmentTarget(target_id, [KDMAValue(kdma='Test_KDMA', value=0.5, parameters=parameters)])
-        ITMSession.alignment_data[target_id] = alignment_target
+        self.alignment_data[target_id] = alignment_target
         return alignment_target
 
 
@@ -232,14 +239,14 @@ class ITMSession:
             alignment_type = kdma + "-" + self.itm_scenario.alignment_target.id
             timestamp = f"{scenario_end_time:%Y%m%d-%H.%M.%S}" # e.g., 20240821-18.22.53
             filename = f"{self.adm_profile.replace(' ','-')}-" if self.adm_profile else ''
-            filename += f"{ITMSession.EVALUATION_TYPE.replace(' ','')}-{self.itm_scenario.id.replace(' ', '_')}-{self.itm_scenario.ta1_name}-{alignment_type.replace(' ', '_')}-{self.adm_name}-{timestamp}"
+            filename += f"{self.EVALUATION_TYPE.replace(' ','')}-{self.itm_scenario.id.replace(' ', '_')}-{self.itm_scenario.ta1_name}-{alignment_type.replace(' ', '_')}-{self.adm_name}-{timestamp}"
             self.history.write_to_json_file(filename, self.save_history_to_s3)
         if self.return_scenario_history:
             if builtins.testing: # Don't print full history
                 self.state.unstructured = dumps({'metadata': self.history.evaluation_info}, indent=2) + os.linesep + self.state.unstructured
             else:
                 self.state.unstructured = dumps({'history': self.history.history, 'metadata': self.history.evaluation_info, 'results': self.history.results}, indent=2) + os.linesep + self.state.unstructured
-        self.history.clear_history()
+        #self.history.clear_history()  # TODO TBDDAG
 
 
     @staticmethod
@@ -479,7 +486,10 @@ class ITMSession:
             max_scenarios = None
         self.itm_scenarios = []
         self.session_type = session_type
-        self.history.clear_history()
+        config_param = adm_profile # TODO Validate?
+        self.init_config(config_param)
+        builtins.config_group = config_param
+        ITMTa1Controller.set_config(config_param)
         self.time_started = time.time()
 
         ta1_names = []
@@ -512,7 +522,7 @@ class ITMSession:
             # Try to get TA1 data, otherwise Fail
             try:
                 ITMSession.init_ta1_data(ta1_names)
-                ITMSession.alignment_data.clear() # Clear alignment data cache
+                self.alignment_data.clear() # Clear alignment data cache
             except:
                 logging.exception("%s: Exception communicating with TA1; is the TA1 server running?  Ending session.", self.log_id)
                 self._end_session() # Exception here ends the session
@@ -520,9 +530,9 @@ class ITMSession:
 
         # Get scenario path based on evaluation type and number
         if self.session_type != 'test':
-            scenario_path = f"{ITMSession.SCENARIO_DIRECTORY}/"
-        elif ITMSession.EVALUATION_NUMBER <= 5: # through Phase 1
-            scenario_path = f"swagger_server/itm/data/{ITMSession.EVALUATION_TYPE}/test/"
+            scenario_path = f"{self.SCENARIO_DIRECTORY}/"
+        elif self.EVALUATION_NUMBER <= 5: # through Phase 1
+            scenario_path = f"swagger_server/itm/data/{self.EVALUATION_TYPE}/test/"
         else: # after Phase 1
             scenario_path = f"swagger_server/itm/data/domains/{domain}/test/"
 

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -50,7 +50,7 @@ class ITMSession:
         """
         Initialize an ITMSession.
         """
-        self.init_config('DEFAULT')
+        self.init_config(self.initial_config_group)
 
         self.session_id = None
         self.log_id = None
@@ -111,22 +111,25 @@ class ITMSession:
             ITMSession.alignment_ids[ta1_name] = [
                 alignment_target_id for alignment_target_id in ITMTa1Controller.get_alignment_target_ids(ta1_name)
             ]
-        logging.info("Done.")
+        logging.info("TA1 configuration loaded.")
 
 
-    def init_config(self, config_group: str):
-        config = ITMSession.config
-        self.SCENARIO_DIRECTORY = config[config_group]['SCENARIO_DIRECTORY']
-        self.EVALUATION_TYPE = config[config_group]['EVALUATION_TYPE']
-        self.EVALUATION_NAME = config[config_group]['EVAL_NAME']
-        self.EVALUATION_NUMBER = int(self.config[config_group]['EVAL_NUMBER'])
+    def init_config(self, config_group: str) -> bool:
+        if not self.config.has_section(config_group):
+            return False
+        cfg = self.config[config_group]
+        self.SCENARIO_DIRECTORY = cfg['SCENARIO_DIRECTORY']
+        self.EVALUATION_TYPE = cfg['EVALUATION_TYPE']
+        self.EVALUATION_NAME = cfg['EVAL_NAME']
+        self.EVALUATION_NUMBER = int(cfg['EVAL_NUMBER'])
         # Don't request session alignment from TA1 at the end of a session
-        self.calc_alignment = self.config[config_group].getboolean("CALC_ALIGNMENT", fallback=True)
+        self.calc_alignment = cfg.getboolean("CALC_ALIGNMENT", fallback=True)
         # This determines whether the server saves history to JSON
-        self.save_history = self.config[config_group].getboolean("SAVE_HISTORY")
+        self.save_history = cfg.getboolean("SAVE_HISTORY")
         # save_history must also be True
-        self.save_history_to_s3 = self.config[config_group].getboolean("SAVE_HISTORY_TO_S3")
-        self.history = ITMHistory(config) # TODO Move to start_session?
+        self.save_history_to_s3 = cfg.getboolean("SAVE_HISTORY_TO_S3")
+        self.history = ITMHistory(config_group)
+        return True
 
 
     def load_alignment_target(self, target_id, ta1_name):
@@ -246,7 +249,7 @@ class ITMSession:
                 self.state.unstructured = dumps({'metadata': self.history.evaluation_info}, indent=2) + os.linesep + self.state.unstructured
             else:
                 self.state.unstructured = dumps({'history': self.history.history, 'metadata': self.history.evaluation_info, 'results': self.history.results}, indent=2) + os.linesep + self.state.unstructured
-        #self.history.clear_history()  # TODO TBDDAG
+        self.history.clear_history()
 
 
     @staticmethod
@@ -424,7 +427,7 @@ class ITMSession:
         except:
             logging.exception("%s: Exception getting next scenario; ending session.", self.log_id)
             self._end_session() # Exception here ends the session
-            return 'Exception getting next scenario; ending session.', 503
+            return 'Exception getting next scenario; ending session.', 500
 
     def _end_session(self) -> Scenario:
         self.session_complete = True
@@ -486,10 +489,11 @@ class ITMSession:
             max_scenarios = None
         self.itm_scenarios = []
         self.session_type = session_type
-        config_param = adm_profile # TODO Validate?
-        self.init_config(config_param)
-        builtins.config_group = config_param
-        ITMTa1Controller.set_config(config_param)
+        self.config_group = adm_profile if adm_profile else self.initial_config_group
+        if not self.init_config(self.config_group):
+            logging.exception("%s: Invalid configuration profile %s.  Aborting session.", self.log_id, self.config_group)
+            return f"Invalid configuration profile {self.config_group}.  Aborting session.", 400
+        #builtins.config_group = self.config_group # TODO TBDDAG remove/change, or keep for SoarTech
         self.time_started = time.time()
 
         ta1_names = []
@@ -524,9 +528,9 @@ class ITMSession:
                 ITMSession.init_ta1_data(ta1_names)
                 self.alignment_data.clear() # Clear alignment data cache
             except:
-                logging.exception("%s: Exception communicating with TA1; is the TA1 server running?  Ending session.", self.log_id)
+                logging.exception("%s: Exception communicating with TA1; is the TA1 server running?  Aborting session.", self.log_id)
                 self._end_session() # Exception here ends the session
-                return 'Exception communicating with TA1; is the TA1 server running?  Ending session.', 503
+                return 'Exception communicating with TA1; is the TA1 server running?  Aborting session.', 503
 
         # Get scenario path based on evaluation type and number
         if self.session_type != 'test':
@@ -538,10 +542,13 @@ class ITMSession:
 
         num_read_scenarios = 0
         for ta1_name in ta1_names:
+            # Tell TA1 controller to load the specified configuration if it hasn't already
+            ITMTa1Controller.load_config(ta1_name, self.config_group)
+
             if self.session_type == 'test':
                 scenarios = ITMSession._get_file_names(scenario_path)
             else:
-                scenarios = ITMTa1Controller.get_filenames(ta1_name, kdma_training)
+                scenarios = ITMTa1Controller.get_scenarios(ta1_name, self.config_group, kdma_training)
 
             ta1_scenarios = []
             scenario_ctr = 0
@@ -553,7 +560,7 @@ class ITMSession:
                     itm_scenario.generate_scenario_data()
                 except FileNotFoundError as fnfe:
                     logging.fatal("Could not read filename '%s.'  Check your TA3 server configuration?", fnfe.filename)
-                    return f"Could not read filename '{fnfe.filename}.'  Check your TA3 server configuration?", 503
+                    return f"Could not read filename '{fnfe.filename}.'  Check your TA3 server configuration?", 500
 
                 if ta1_name == "test":
                     ta1_scenarios.append(deepcopy(itm_scenario))
@@ -571,7 +578,7 @@ class ITMSession:
                                 ta1_scenarios[scenario_ctr].alignment_target = alignment_target
                                 if self.ta1_integration:
                                     ta1_scenarios[scenario_ctr].set_controller( # Always create a new controller for each scenario.
-                                        ITMTa1Controller.create_controller(ta1_name, target_id, alignment_target))
+                                        ITMTa1Controller.create_controller(ta1_name, self.config_group, target_id, alignment_target))
                                 scenario_ctr += 1
                             except Exception as e:
                                 logging.fatal("%s: Couldn't obtain alignment target '%s'. Check your TA3 server configuration or connection to TA1.",
@@ -581,12 +588,12 @@ class ITMSession:
 
                     try:
                         # Get a list of alignment target IDs that apply to the given scenario so we can create a scenario for each target
-                        alignment_target_ids = ITMTa1Controller.get_target_ids(ta1_name, itm_scenario)
+                        alignment_target_ids = ITMTa1Controller.get_target_ids(ta1_name, self.config_group, itm_scenario)
                         scenario_ctr = __load_scenarios(alignment_target_ids, scenario_ctr) \
                             if not self.kdma_training else __load_scenarios([alignment_target_ids[0]], scenario_ctr)
                     except Exception as e:
                         logging.exception(e)
-                        return f"Problem loading TA3 server configuration.", 503
+                        return f"Problem loading TA3 server configuration.", 500
 
             self.itm_scenarios.extend(ta1_scenarios)
             num_read_scenarios += len(ta1_scenarios)

--- a/swagger_server/itm/itm_session.py
+++ b/swagger_server/itm/itm_session.py
@@ -543,7 +543,7 @@ class ITMSession:
         num_read_scenarios = 0
         for ta1_name in ta1_names:
             # Tell TA1 controller to load the specified configuration if it hasn't already
-            ITMTa1Controller.load_config(ta1_name, self.config_group)
+            ITMTa1Controller.set_config(ta1_name, self.config_group)
 
             if self.session_type == 'test':
                 scenarios = ITMSession._get_file_names(scenario_path)

--- a/swagger_server/itm/ta1/adept_ta1_controller.py
+++ b/swagger_server/itm/ta1/adept_ta1_controller.py
@@ -1,11 +1,13 @@
 import requests
 import urllib
 from swagger_server.models import KDMAValue
-from .itm_ta1_controller import ITMTa1Controller
+from .itm_ta1_controller import ITMTa1Controller, TA1Config
 import re
 import os
 import logging
 import builtins
+from dataclasses import dataclass
+from swagger_server.config_util import Configuration
 from swagger_server.itm.utils import generate_list, resolve_tokens, load_scenario_ids, load_alignment_ids
 
 scenarioRegex = re.compile(r'^ADEPT_(EVAL|TRAIN)_(?P<group>[^_]+)_SCENARIOS$', re.IGNORECASE)
@@ -13,57 +15,101 @@ targetRegex = re.compile(r'^ADEPT_(?P<group>[^_]+)_ALIGNMENT_TARGETS$', re.IGNOR
 distributionRegex = re.compile(r'^ADEPT_(?P<group>[^_]+)_ALIGNMENT_DISTRIBUTION_TARGET$', re.IGNORECASE)
 testingMode = getattr(builtins, "testing", False)
 
+@dataclass
+class AdeptConfig(TA1Config):
+    EVAL_FILENAMES: list
+    TRAIN_FILENAMES: list
+    evaluationScenarios: dict
+    trainingScenarios: dict
+    alignmentTargets: dict
+    distributionTargets: dict
+    target_to_group: dict
+
+
 class AdeptTa1Controller(ITMTa1Controller):
 
-    evaluationScenarios = {}
-    trainingScenarios = {}
-    alignmentTargets = {}
-    distributionTargets = {}
+    @classmethod
+    def load_config(cls, config_group) -> AdeptConfig:
+        if config_group not in cls.configurations.keys():
+            cls.configurations[config_group] = cls.create_config(config_group)
+        return cls.configurations[config_group]
 
-    cfg = ITMTa1Controller.config[ITMTa1Controller.config_group]
 
-    scenario_directory = cfg['SCENARIO_DIRECTORY']
-    try:
-        scenario_files = set(os.listdir(scenario_directory))
-    except OSError:
-        logging.fatal("Invalid filepath. Please check the SCENARIO_DIRECTORY variable in the config.ini file.")
-        exit(1)
+    @classmethod
+    def create_config(cls, config_group: str) -> TA1Config:
+        logging.info('One-time ADEPT creation of %s configuration.', config_group)
+        evaluationScenarios = {}
+        trainingScenarios = {}
+        alignmentTargets = {}
+        distributionTargets = {}
 
-    scenario_ids = load_scenario_ids(scenario_directory, scenario_files)
-    alignment_ids = set() if testingMode else load_alignment_ids(ITMTa1Controller.get_contact_info('adept'), '/api/v1/alignment_target_ids')
+        cfg = cls.config[config_group]
+        scenario_directory = cfg['SCENARIO_DIRECTORY']
+        logging.info("Scenario directory is %s.", scenario_directory)
+        try:
+            scenario_files = set(os.listdir(scenario_directory))
+        except OSError:
+            logging.fatal("Invalid filepath. Please check the SCENARIO_DIRECTORY variable in the config.ini file.")
+            exit(1)
 
-    ADEPT_EVAL_FILENAMES = sorted(resolve_tokens(cfg['ADEPT_EVAL_FILENAMES'], scenario_files))
-    ADEPT_TRAIN_FILENAMES = sorted(resolve_tokens(cfg['ADEPT_TRAIN_FILENAMES'], scenario_files))
+        scenario_ids = load_scenario_ids(scenario_directory, scenario_files)
+        EVAL_FILENAMES = sorted(resolve_tokens(cfg['ADEPT_EVAL_FILENAMES'], scenario_files))
+        TRAIN_FILENAMES = sorted(resolve_tokens(cfg['ADEPT_TRAIN_FILENAMES'], scenario_files))
 
-    for key, value in cfg.items():
-        if scenarioMatch := scenarioRegex.match(key):
-            mode = scenarioMatch.group(1).lower()
-            group = scenarioMatch.group('group').lower()
-            correct_dict = evaluationScenarios if mode == 'eval' else trainingScenarios
-            correct_dict[group] = resolve_tokens(value, scenario_ids)
-        elif targetMatch := targetRegex.match(key):
-            group = targetMatch.group('group').lower()
-            tokens = sorted(generate_list(value))
-            if testingMode:
-                suspects = [t for t in tokens if any(c in t for c in "*?[]()\\{\\}+^$|")]
-                if len(suspects) > 0:
-                    logging.fatal("Found alignment target IDs suspected to be Glob or Regex patterns. These are not supported in testing mode and will likely cause a server crash.")
-                alignmentTargets[group] = tokens
-            else:
-                alignmentTargets[group] = sorted(resolve_tokens(value, alignment_ids))
-        elif distributionMatch := distributionRegex.match(key):
-            group = distributionMatch.group('group').lower()
-            distributionTargets[group] = value.strip()
-   
-    target_to_group = {target: group for group, targets in alignmentTargets.items() for target in targets}
-   
-    def __init__(self, alignment_target_id, alignment_target = None):
-        super().__init__(self.get_ta1name(), alignment_target_id, alignment_target)
+        for key, value in cfg.items():
+            if scenarioMatch := scenarioRegex.match(key):
+                mode = scenarioMatch.group(1).lower()
+                group = scenarioMatch.group('group').lower()
+                correct_dict = evaluationScenarios if mode == 'eval' else trainingScenarios
+                correct_dict[group] = resolve_tokens(value, scenario_ids)
+            elif targetMatch := targetRegex.match(key):
+                group = targetMatch.group('group').lower()
+                tokens = sorted(generate_list(value))
+                if testingMode:
+                    suspects = [t for t in tokens if any(c in t for c in "*?[]()\\{\\}+^$|")]
+                    if len(suspects) > 0:
+                        logging.fatal("Found alignment target IDs suspected to be Glob or Regex patterns. These are not supported in testing mode and will likely cause a server crash.")
+                    alignmentTargets[group] = tokens
+                else:
+                    alignmentTargets[group] = sorted(resolve_tokens(value, cls.alignment_ids))
+            elif distributionMatch := distributionRegex.match(key):
+                group = distributionMatch.group('group').lower()
+                distributionTargets[group] = value.strip()
+
+        target_to_group = {target: group for group, targets in alignmentTargets.items() for target in targets}
+
+        ta1_config = AdeptConfig(ta1_name=cls.get_ta1name(),
+                                 contact_url=cfg[f"{cls.get_ta1name().upper()}_URL"],
+                                 EVAL_FILENAMES=EVAL_FILENAMES, TRAIN_FILENAMES=TRAIN_FILENAMES,
+                                 evaluationScenarios=evaluationScenarios, trainingScenarios=trainingScenarios,
+                                 alignmentTargets=alignmentTargets, distributionTargets=distributionTargets,
+                                 target_to_group=target_to_group)
+        return ta1_config
+
+
+    # Static initialization, but also note call to init_config after the class definition
+    configurations = {} # Maps configuration group strings to AdeptConfig objects
+    config = None
+    alignment_ids = None
+    server_url = None
+
+
+    @classmethod
+    def init_config(cls):
+        cls.config = Configuration.get_config()
+        cls.server_url = cls.config[builtins.config_group][f"{cls.get_ta1name().upper()}_URL"]
+        cls.alignment_ids = set() if testingMode else load_alignment_ids(cls.get_alignment_ids_path())
+        logging.info("Loaded %d alignment ids from TA1 server.", len(cls.alignment_ids))
+        cls.configurations[builtins.config_group] = AdeptTa1Controller.create_config(builtins.config_group)
+
+    def __init__(self, config_group, alignment_target_id, alignment_target = None):
+        super().__init__(alignment_target_id, alignment_target)
         self.adept_populations = False
+        self.ta1_config = AdeptTa1Controller.load_config(config_group)
 
     @staticmethod
     def get_server_url() -> str:
-        return ITMTa1Controller.get_contact_info(AdeptTa1Controller.get_ta1name())
+        return AdeptTa1Controller.server_url
 
     @staticmethod
     def get_ta1name() -> str:
@@ -78,16 +124,18 @@ class AdeptTa1Controller(ITMTa1Controller):
           return f"{AdeptTa1Controller.get_server_url()}/api/v1/alignment_target/{alignment_target_id}"
 
     @staticmethod
-    def get_filenames(kdma_training) -> list[str]:
-        return AdeptTa1Controller.ADEPT_TRAIN_FILENAMES if kdma_training else AdeptTa1Controller.ADEPT_EVAL_FILENAMES
+    def get_filenames(config_group, kdma_training) -> list[str]:
+        ta1_config: AdeptConfig = AdeptTa1Controller.load_config(config_group)
+        return ta1_config.TRAIN_FILENAMES if kdma_training else ta1_config.EVAL_FILENAMES
 
     @staticmethod
-    def get_target_ids(itm_scenario) -> list[str]:
+    def get_target_ids(config_group, itm_scenario) -> list[str]:
+        ta1_config = AdeptTa1Controller.load_config(config_group)
         target_ids: list[str] = []
-        source = AdeptTa1Controller.trainingScenarios if itm_scenario.training else AdeptTa1Controller.evaluationScenarios
+        source = ta1_config.trainingScenarios if itm_scenario.training else ta1_config.evaluationScenarios
         for group, scenarioList in source.items():
             if itm_scenario.id in scenarioList:
-                target_ids.extend(AdeptTa1Controller.alignmentTargets.get(group, ()))
+                target_ids.extend(ta1_config.alignmentTargets.get(group, ()))
         return target_ids
 
     def supports_probe_alignment(self) -> bool:
@@ -118,9 +166,9 @@ class AdeptTa1Controller(ITMTa1Controller):
                 "session_id_1_or_target_id": self.session_id,
                 "session_id_2_or_target_id": actual_target_id
             }
-            group = AdeptTa1Controller.target_to_group.get(actual_target_id)
+            group = self.ta1_config.target_to_group.get(actual_target_id)
             if group:
-                pop_id = AdeptTa1Controller.distributionTargets.get(group)
+                pop_id = self.ta1_config.distributionTargets.get(group)
                 if pop_id:
                     params['target_pop_id'] = pop_id
         else:
@@ -130,3 +178,6 @@ class AdeptTa1Controller(ITMTa1Controller):
                 "target_id": self.alignment_target_id if not target_id else target_id
             }
         return f"{base_url}?{urllib.parse.urlencode(params)}"
+
+
+AdeptTa1Controller.init_config()

--- a/swagger_server/itm/ta1/adept_ta1_controller.py
+++ b/swagger_server/itm/ta1/adept_ta1_controller.py
@@ -79,7 +79,6 @@ class AdeptTa1Controller(ITMTa1Controller):
         target_to_group = {target: group for group, targets in alignmentTargets.items() for target in targets}
 
         ta1_config = AdeptConfig(ta1_name=cls.get_ta1name(),
-                                 contact_url=cfg[f"{cls.get_ta1name().upper()}_URL"],
                                  EVAL_FILENAMES=EVAL_FILENAMES, TRAIN_FILENAMES=TRAIN_FILENAMES,
                                  evaluationScenarios=evaluationScenarios, trainingScenarios=trainingScenarios,
                                  alignmentTargets=alignmentTargets, distributionTargets=distributionTargets,

--- a/swagger_server/itm/ta1/adept_ta1_controller.py
+++ b/swagger_server/itm/ta1/adept_ta1_controller.py
@@ -49,8 +49,7 @@ class AdeptTa1Controller(ITMTa1Controller):
         try:
             scenario_files = set(os.listdir(scenario_directory))
         except OSError:
-            logging.fatal("Invalid filepath. Please check the SCENARIO_DIRECTORY variable in the config.ini file.")
-            exit(1)
+            raise RuntimeError("Invalid filepath. Please check the SCENARIO_DIRECTORY variable in the config.ini file.")
 
         scenario_ids = load_scenario_ids(scenario_directory, scenario_files)
         EVAL_FILENAMES = sorted(resolve_tokens(cfg['ADEPT_EVAL_FILENAMES'], scenario_files))

--- a/swagger_server/itm/ta1/itm_ta1_controller.py
+++ b/swagger_server/itm/ta1/itm_ta1_controller.py
@@ -1,35 +1,36 @@
 import requests
 import json
 import urllib
-import builtins
 from abc import ABC, abstractmethod
 from importlib import import_module
 from math import isnan
 from swagger_server.models import (
     ProbeResponse, AlignmentResults, AlignmentTarget
 )
-from swagger_server.config_util import Configuration
+from dataclasses import dataclass
+
+@dataclass
+class TA1Config:
+    ta1_name: str
+    contact_url: str
+
 
 class ITMTa1Controller(ABC):
-    config = Configuration.get_config()
-    config_group = builtins.config_group
-
-    def __init__(self, scene_type: str, alignment_target_id, alignment_target = None):
+    def __init__(self, alignment_target_id, alignment_target = None):
         self.session_id = ''
         self.alignment_target_id = alignment_target_id
         self.alignment_target = alignment_target
-        self.url = self.get_contact_info(scene_type)
+        self.url = self.get_server_url()
 
     @staticmethod
-    def set_config(config_group):
-        ITMTa1Controller.config_group = config_group
-        print(f'ITMTa1Controller: Setting config to {config_group}.')
+    def load_config(scene_type: str, config_group: str):
+        ITMTa1Controller.__get_static_ref(scene_type).load_config(config_group)
 
     @staticmethod
-    def create_controller(scene_type, alignment_target_id=None, alignment_target=None):
+    def create_controller(scene_type, config_group, alignment_target_id=None, alignment_target=None):
         try:
             klass: ITMTa1Controller = ITMTa1Controller.__get_static_ref(scene_type)
-            instance = klass(alignment_target_id, alignment_target)
+            instance = klass(config_group, alignment_target_id, alignment_target)
             return instance
         except (ImportError, AttributeError, TypeError) as e:
             print(f"Error instantiating '{scene_type}' TA1 controller from factory: {e}")
@@ -39,14 +40,6 @@ class ITMTa1Controller(ABC):
     def __get_static_ref(scene_type: str):
         module = import_module(f"swagger_server.itm.ta1.{scene_type}_ta1_controller")
         return getattr(module, f"{scene_type.capitalize()}Ta1Controller")
-
-    @staticmethod
-    def get_contact_info(ta1_name: str) -> str:
-        url = ITMTa1Controller.config[ITMTa1Controller.config_group][f"{ta1_name.upper()}_URL"]
-        # Technically this `if` block should never evaluate to True since configs are mandatory, but just in case.
-        if url is None or url == "":
-            url = "localhost"
-        return url
 
     @staticmethod
     @abstractmethod
@@ -86,21 +79,16 @@ class ITMTa1Controller(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_filenames(kdma_training):
+    def get_filenames(config_group, kdma_training):
         ...
 
     @staticmethod
-    def get_filenames(ta1_name, kdma_training):
-        return ITMTa1Controller.__get_static_ref(ta1_name).get_filenames(kdma_training)
+    def get_scenarios(ta1_name, config_group, kdma_training):
+        return ITMTa1Controller.__get_static_ref(ta1_name).get_filenames(config_group, kdma_training)
 
     @staticmethod
-    @abstractmethod
-    def get_target_ids(itm_scenario) -> list[str]:
-        ...
-
-    @staticmethod
-    def get_target_ids(ta1_name: str, itm_scenario) -> list[str]:
-        return ITMTa1Controller.__get_static_ref(ta1_name).get_target_ids(itm_scenario)
+    def get_target_ids(ta1_name: str, config_group: str, itm_scenario) -> list[str]:
+        return ITMTa1Controller.__get_static_ref(ta1_name).get_target_ids(config_group, itm_scenario)
 
     # Note: this method is currently unused but remains valid from an API perspective; and we might want to use it someday.
     @staticmethod

--- a/swagger_server/itm/ta1/itm_ta1_controller.py
+++ b/swagger_server/itm/ta1/itm_ta1_controller.py
@@ -21,6 +21,11 @@ class ITMTa1Controller(ABC):
         self.url = self.get_contact_info(scene_type)
 
     @staticmethod
+    def set_config(config_group):
+        ITMTa1Controller.config_group = config_group
+        print(f'ITMTa1Controller: Setting config to {config_group}.')
+
+    @staticmethod
     def create_controller(scene_type, alignment_target_id=None, alignment_target=None):
         try:
             klass: ITMTa1Controller = ITMTa1Controller.__get_static_ref(scene_type)

--- a/swagger_server/itm/ta1/itm_ta1_controller.py
+++ b/swagger_server/itm/ta1/itm_ta1_controller.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 @dataclass
 class TA1Config:
     ta1_name: str
-    contact_url: str
 
 
 class ITMTa1Controller(ABC):
@@ -23,7 +22,7 @@ class ITMTa1Controller(ABC):
         self.url = self.get_server_url()
 
     @staticmethod
-    def load_config(scene_type: str, config_group: str):
+    def set_config(scene_type: str, config_group: str):
         ITMTa1Controller.__get_static_ref(scene_type).load_config(config_group)
 
     @staticmethod
@@ -49,6 +48,21 @@ class ITMTa1Controller(ABC):
     @staticmethod
     @abstractmethod
     def get_ta1name() -> str:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def load_config(cls, config_group: str):
+        ...
+
+    @classmethod
+    @abstractmethod
+    def create_config(cls, config_group: str):
+        ...
+
+    @classmethod
+    @abstractmethod
+    def init_config(cls):
         ...
 
     @staticmethod

--- a/swagger_server/itm/ta1/soartech_ta1_controller.py
+++ b/swagger_server/itm/ta1/soartech_ta1_controller.py
@@ -1,30 +1,70 @@
 import requests
 import urllib
+import logging
 import builtins
+from dataclasses import dataclass
 from swagger_server.config_util import Configuration
 from swagger_server.models import KDMAProfile
-from .itm_ta1_controller import ITMTa1Controller
+from .itm_ta1_controller import ITMTa1Controller, TA1Config
+
+@dataclass
+class SoartechConfig(TA1Config):
+    EVAL_FILENAMES: list
+    TRAIN_FILENAMES: list
+    eval_qol_scenarios: list
+    eval_vol_scenarios: list
+    train_qol_scenarios: list
+    train_vol_scenarios: list
+    qol_alignmentTargets: list
+    vol_alignmentTargets: list
 
 
 class SoartechTa1Controller(ITMTa1Controller):
 
-    config = Configuration.get_config()[builtins.config_group]
+    @classmethod
+    def load_config(cls, config_group) -> SoartechConfig:
+        if config_group not in cls.configurations.keys():
+            cls.configurations[config_group] = cls.create_config(config_group)
+        return cls.configurations[config_group]
 
-    SOARTECH_EVAL_FILENAMES = config['SOARTECH_EVAL_FILENAMES'].replace('\n','').split(',')
-    SOARTECH_TRAIN_FILENAMES = config['SOARTECH_TRAIN_FILENAMES'].replace('\n','').split(',')
-    SOARTECH_EVAL_QOL_SCENARIOS = config['SOARTECH_EVAL_QOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_EVAL_VOL_SCENARIOS = config['SOARTECH_EVAL_VOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_TRAIN_QOL_SCENARIOS = config['SOARTECH_TRAIN_QOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_TRAIN_VOL_SCENARIOS = config['SOARTECH_TRAIN_VOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_QOL_ALIGNMENT_TARGETS = config['SOARTECH_QOL_ALIGNMENT_TARGETS'].replace('\n','').split(',')
-    SOARTECH_VOL_ALIGNMENT_TARGETS = config['SOARTECH_VOL_ALIGNMENT_TARGETS'].replace('\n','').split(',')
+    @classmethod
+    def create_config(cls, config_group: str) -> TA1Config:
+        logging.info('One-time Soartech creation of %s configuration.', config_group)
 
-    def __init__(self, alignment_target_id, alignment_target = None):
+        cfg = cls.config[config_group]
+        ta1_config = SoartechConfig(ta1_name=cls.get_ta1name(),
+                                    EVAL_FILENAMES=cfg['SOARTECH_EVAL_FILENAMES'].replace('\n','').split(','),
+                                    TRAIN_FILENAMES=cfg['SOARTECH_TRAIN_FILENAMES'].replace('\n','').split(','),
+                                    eval_qol_scenarios=cfg['SOARTECH_EVAL_QOL_SCENARIOS'].replace('\n','').split(','),
+                                    eval_vol_scenarios=cfg['SOARTECH_EVAL_VOL_SCENARIOS'].replace('\n','').split(','),
+                                    train_qol_scenarios=cfg['SOARTECH_TRAIN_QOL_SCENARIOS'].replace('\n','').split(','),
+                                    train_vol_scenarios=cfg['SOARTECH_TRAIN_VOL_SCENARIOS'].replace('\n','').split(','),
+                                    qol_alignmentTargets=cfg['SOARTECH_QOL_ALIGNMENT_TARGETS'].replace('\n','').split(','),
+                                    vol_alignmentTargets=cfg['SOARTECH_VOL_ALIGNMENT_TARGETS'].replace('\n','').split(',')
+        )
+        return ta1_config
+
+
+    # Static initialization, but also note call to init_config after the class definition
+    configurations = {} # Maps configuration group strings to AdeptConfig objects
+    config = None
+    server_url = None
+
+
+    @classmethod
+    def init_config(cls):
+        cls.config = Configuration.get_config()
+        cls.server_url = cls.config[builtins.config_group][f"{cls.get_ta1name().upper()}_URL"]
+        cls.configurations[builtins.config_group] = SoartechTa1Controller.create_config(builtins.config_group)
+
+
+    def __init__(self, config_group, alignment_target_id, alignment_target = None):
         super().__init__(self.get_ta1name(), alignment_target_id, alignment_target)
+        self.ta1_config = SoartechTa1Controller.load_config(config_group)
 
     @staticmethod
     def get_server_url() -> str:
-        return ITMTa1Controller.get_contact_info(SoartechTa1Controller.get_ta1name())
+        return SoartechTa1Controller.server_url
 
     @staticmethod
     def get_ta1name() -> str:
@@ -39,16 +79,18 @@ class SoartechTa1Controller(ITMTa1Controller):
           return f"{SoartechTa1Controller.get_server_url()}/api/v1/alignment_target/{alignment_target_id}"
 
     @staticmethod
-    def get_filenames(kdma_training) -> list[str]:
-        return SoartechTa1Controller.SOARTECH_TRAIN_FILENAMES if kdma_training else SoartechTa1Controller.SOARTECH_EVAL_FILENAMES
+    def get_filenames(config_group, kdma_training) -> list[str]:
+        ta1_config: SoartechConfig = SoartechConfig.load_config(config_group)
+        return ta1_config.TRAIN_FILENAMES if kdma_training else ta1_config.EVAL_FILENAMES
 
     @staticmethod
-    def get_target_ids(itm_scenario) -> list[str]:
+    def get_target_ids(config_group, itm_scenario) -> list[str]:
+        ta1_config: SoartechConfig = SoartechConfig.load_config(config_group)
         target_ids: list[str] = []
-        if itm_scenario.id in (SoartechTa1Controller.SOARTECH_TRAIN_QOL_SCENARIOS if itm_scenario.training else SoartechTa1Controller.SOARTECH_EVAL_QOL_SCENARIOS):
-            target_ids.extend(SoartechTa1Controller.SOARTECH_QOL_ALIGNMENT_TARGETS)
-        if itm_scenario.id in (SoartechTa1Controller.SOARTECH_TRAIN_VOL_SCENARIOS if itm_scenario.training else SoartechTa1Controller.SOARTECH_EVAL_VOL_SCENARIOS):
-            target_ids.extend(SoartechTa1Controller.SOARTECH_VOL_ALIGNMENT_TARGETS)
+        if itm_scenario.id in (ta1_config.train_qol_scenarios if itm_scenario.training else ta1_config.eval_qol_scenarios):
+            target_ids.extend(ta1_config.qol_alignmentTargets)
+        if itm_scenario.id in (ta1_config.train_vol_scenarios if itm_scenario.training else ta1_config.eval_vol_scenarios):
+            target_ids.extend(ta1_config.vol_alignmentTargets)
         return target_ids
 
     def new_session(self, context=None) -> any:
@@ -74,3 +116,6 @@ class SoartechTa1Controller(ITMTa1Controller):
             "target_id": self.alignment_target_id if not target_id else target_id
         }
         return f"{base_url}?{urllib.parse.urlencode(params)}"
+
+
+SoartechTa1Controller.init_config()

--- a/swagger_server/itm/ta1/soartech_ta1_controller.py
+++ b/swagger_server/itm/ta1/soartech_ta1_controller.py
@@ -1,19 +1,23 @@
 import requests
 import urllib
+import builtins
+from swagger_server.config_util import Configuration
 from swagger_server.models import KDMAProfile
 from .itm_ta1_controller import ITMTa1Controller
 
 
 class SoartechTa1Controller(ITMTa1Controller):
 
-    SOARTECH_EVAL_FILENAMES = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_EVAL_FILENAMES'].replace('\n','').split(',')
-    SOARTECH_TRAIN_FILENAMES = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_TRAIN_FILENAMES'].replace('\n','').split(',')
-    SOARTECH_EVAL_QOL_SCENARIOS = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_EVAL_QOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_EVAL_VOL_SCENARIOS = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_EVAL_VOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_TRAIN_QOL_SCENARIOS = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_TRAIN_QOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_TRAIN_VOL_SCENARIOS = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_TRAIN_VOL_SCENARIOS'].replace('\n','').split(',')
-    SOARTECH_QOL_ALIGNMENT_TARGETS = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_QOL_ALIGNMENT_TARGETS'].replace('\n','').split(',')
-    SOARTECH_VOL_ALIGNMENT_TARGETS = ITMTa1Controller.config[ITMTa1Controller.config_group]['SOARTECH_VOL_ALIGNMENT_TARGETS'].replace('\n','').split(',')
+    config = Configuration.get_config()[builtins.config_group]
+
+    SOARTECH_EVAL_FILENAMES = config['SOARTECH_EVAL_FILENAMES'].replace('\n','').split(',')
+    SOARTECH_TRAIN_FILENAMES = config['SOARTECH_TRAIN_FILENAMES'].replace('\n','').split(',')
+    SOARTECH_EVAL_QOL_SCENARIOS = config['SOARTECH_EVAL_QOL_SCENARIOS'].replace('\n','').split(',')
+    SOARTECH_EVAL_VOL_SCENARIOS = config['SOARTECH_EVAL_VOL_SCENARIOS'].replace('\n','').split(',')
+    SOARTECH_TRAIN_QOL_SCENARIOS = config['SOARTECH_TRAIN_QOL_SCENARIOS'].replace('\n','').split(',')
+    SOARTECH_TRAIN_VOL_SCENARIOS = config['SOARTECH_TRAIN_VOL_SCENARIOS'].replace('\n','').split(',')
+    SOARTECH_QOL_ALIGNMENT_TARGETS = config['SOARTECH_QOL_ALIGNMENT_TARGETS'].replace('\n','').split(',')
+    SOARTECH_VOL_ALIGNMENT_TARGETS = config['SOARTECH_VOL_ALIGNMENT_TARGETS'].replace('\n','').split(',')
 
     def __init__(self, alignment_target_id, alignment_target = None):
         super().__init__(self.get_ta1name(), alignment_target_id, alignment_target)

--- a/swagger_server/itm/ta1/soartech_ta1_controller.py
+++ b/swagger_server/itm/ta1/soartech_ta1_controller.py
@@ -59,7 +59,7 @@ class SoartechTa1Controller(ITMTa1Controller):
 
 
     def __init__(self, config_group, alignment_target_id, alignment_target = None):
-        super().__init__(self.get_ta1name(), alignment_target_id, alignment_target)
+        super().__init__(alignment_target_id, alignment_target)
         self.ta1_config = SoartechTa1Controller.load_config(config_group)
 
     @staticmethod
@@ -80,7 +80,7 @@ class SoartechTa1Controller(ITMTa1Controller):
 
     @staticmethod
     def get_filenames(config_group, kdma_training) -> list[str]:
-        ta1_config: SoartechConfig = SoartechConfig.load_config(config_group)
+        ta1_config: SoartechConfig = SoartechTa1Controller.load_config(config_group)
         return ta1_config.TRAIN_FILENAMES if kdma_training else ta1_config.EVAL_FILENAMES
 
     @staticmethod

--- a/swagger_server/itm/utils.py
+++ b/swagger_server/itm/utils.py
@@ -53,9 +53,9 @@ def load_scenario_ids(base_path, scenario_files):
                 pass
     return scenario_ids
 
-def load_alignment_ids(ta1_name, base_url):
+def load_alignment_ids(url):
     try:
-        return set(requests.get(f"{ta1_name}{base_url}").json())
+        return set(requests.get(url).json())
     except Exception:
-        logging.fatal("Could not retrieve alignment IDs from TA1 server.")
+        logging.fatal(f"Could NOT retrieve alignment IDs from TA1 server at {url}.")
     return set()


### PR DESCRIPTION
More often than not these days, we need TA2 to create evaluation sessions with the TA3 server multiple times-- each a different server configuration.  Different configs set up different sets of scenarios, alignment targets, and something other settings.  This requires coordination between TA2 and TA3 such that TA2 tells us when their ADMs are done, then we run a Jenkins script with a different configuration, notify TA2, then they start their ADMs.

This ticket adds the capability for the client to specify a server configuration when starting a session.  The server will update its internal configuration accordingly.  If no configuration is specified, it uses the configuration with which the server was launched (via `-c`, or `DEFAULT` if `-c` wasn't used).

There are a few config parameters that cannot be changed this way.  A server restart will be required:
-  `DEFAULT_DOMAIN`, `SUPPORTED_DOMAINS`, `ALL_TA1_NAMES`, `ADEPT_URL`, and `SOARTECH_URL`

To test:
- For these first tests, point your TA1 to the production server.
- Copy `swagger_server/itm/data/domains/p2triage/config.ini.template` to your local `swagger_server/config.ini`.
  - Override the usual things like `SAVE_HISTORY_TO_S3` (False), `ADEPT_URL` (https://darpaitm.caci.com/adept), and `SCENARIO_DIRECTORY` (only if your scenarios are not in the default location).
  - Start your server with `-t` (for testing), then run the following test configurations, and verify no errors in the output files in `automated_test_results/1411`:
    - `python automated_tester.py --group testing --auto-port --branch 1411`
    - `python automated_tester.py --group train-solo --auto-port --branch 1411`
- Override the various `ADEPT_*_ALIGNMENT_TARGETS` config values throughout your `config.ini` so that there is only 1 or 2 targets per variable, then run:
    - `python itm_minimal_runner.py --session adept --name testrun --profile EVAL_BI`
    - `python itm_minimal_runner.py --session adept --name testrun --profile EVAL_TRI`
    - `python itm_minimal_runner.py --session adept --name testrun --profile EVAL_MULTI`
    - In all cases, make sure the correct scenarios were processed and an alignment score was retrieved from TA1.

Then, rename and replace your `config.ini` with the one I attached below as `config.1411B.ini.txt`, and start the next set of tests.
- Use a local TA1 server pointing to the `main` branch.  Make sure you have the openworld scenarios in your local TA1 server. 
- Run the TA3 server (on the feature branch, of course) with `python -m swagger_server -t`
- Without restarting the TA3 server, run the braindead client (`dev` or `main` branch) in another window (not via the automated tester) with:
  - `python itm_minimal_runner.py --session adept --name testrun --profile JUNE25_OPENWORLD`
  - `python itm_minimal_runner.py --session adept --name testrun --profile APRIL_OPENWORLD`
  - `python itm_minimal_runner.py --session adept --name testrun --profile FEB_OPENWORLD`
  - Make sure the TA3 server loads the correct configuration and the client and server reflect that the correct configuration was served up.
    - Hint:  look for e.g. "Scenario June2025-OW_desert2 complete for target Feb2026-MF-4." in the client output.  And/or, check the server output for e.g. `Scenario June2025-OW_desert2 ended.`  Also see that history was placed in the right folder (e.g., june2025_history_output).
  - Feel free to re-run these client sessions ad nauseum, making sure the correct configuration runs.
- Restart the server with `python -m swagger_server -c APRIL_OPENWORLD`
- Without restarting the TA3 server, run the braindead client in another window (not via the automated tester) with:
  - `python itm_minimal_runner.py --session adept --name testrun`
  - `python itm_minimal_runner.py --session adept --name testrun --profile FEB_OPENWORLD`
  - Ensure that the first run served up the April2026 OW scenarios, and of course the second run served up Feb2026.  Make sure that you got alignment scores-- provided that at least one probe was answered for the given target.
  - Feel free to re-run these client sessions ad nauseum, making sure the correct configuration runs.

<h3>Extra credit</h3>

- Open three separate terminals in the client directory.
- Restart the server with `python -m swagger_server`
- About a second apart, start a client in each of the three other windows, each with a different configuration (from among `APRIL_OPENWORLD`, `FEB_OPENWORLD`, and `JUNE25_OPENWORLD`).
- Use server and client output to ensure that the server seamlessly switched configurations for the various simultaneous clients.

Finally:
- Look at the diffs and the code and see if anything stands out.
- Take a closer look at the SoarTech controller, since those changes weren't tested.  (Nobody's launching a SoarTech controller at this point, but I'd like the controller code to be correct.
- If you didn't do the extra credit, then at least convince yourself that the things that are set statically won't cause problems with multiple clients (subject to the limitations listed above), and that session-level config is properly updated.